### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.5.13](https://github.com/pkgforge/soar/compare/v0.5.12...v0.5.13) - 2025-03-10
+
+### ⛰️  Features
+
+- *(health)* Check if bin is in PATH - ([2c06017](https://github.com/pkgforge/soar/commit/2c06017a11e409b9207d55d86292e984ab105715))
+- *(install)* Add partial support for excluding files on install - ([f496bf5](https://github.com/pkgforge/soar/commit/f496bf5f67dc9c71fab1c61d53e33f8047cab862))
+- *(package)* Track excluded package installation files - ([a7ca6c0](https://github.com/pkgforge/soar/commit/a7ca6c01301784cf6f06c3a31b6bf47f174f39df))
+- *(package)* Handle multiple desktop/icon integration - ([c5b6e4a](https://github.com/pkgforge/soar/commit/c5b6e4aeb8235372b77281b532dfdee7c3b73e79))
+- *(package)* Handle replaced pkg_id - ([61a47fb](https://github.com/pkgforge/soar/commit/61a47fb0aa52e47719c845e21d94e524fa26466e))
+
 ## [0.5.12](https://github.com/pkgforge/soar/compare/v0.5.11...v0.5.12) - 2025-03-02
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "soar-cli"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "clap",
  "futures",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "soar-core"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/soar-cli/Cargo.toml
+++ b/soar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-cli"
-version = "0.5.12"
+version = "0.5.13"
 description = "A modern package manager for Linux"
 default-run = "soar"
 authors.workspace = true
@@ -30,7 +30,7 @@ rusqlite = { workspace = true }
 semver = "1.0.25"
 serde = { workspace = true }
 serde_json = { workspace = true }
-soar-core = { version = "0.1.10", path = "../soar-core" }
+soar-core = { version = "0.2.0", path = "../soar-core" }
 soar-dl = { workspace = true }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.8.20"

--- a/soar-core/CHANGELOG.md
+++ b/soar-core/CHANGELOG.md
@@ -1,4 +1,13 @@
 
+## [0.2.0](https://github.com/pkgforge/soar/compare/soar-core-v0.1.10...soar-core-v0.2.0) - 2025-03-10
+
+### ⛰️  Features
+
+- *(install)* Add partial support for excluding files on install - ([f496bf5](https://github.com/pkgforge/soar/commit/f496bf5f67dc9c71fab1c61d53e33f8047cab862))
+- *(package)* Track excluded package installation files - ([a7ca6c0](https://github.com/pkgforge/soar/commit/a7ca6c01301784cf6f06c3a31b6bf47f174f39df))
+- *(package)* Handle multiple desktop/icon integration - ([c5b6e4a](https://github.com/pkgforge/soar/commit/c5b6e4aeb8235372b77281b532dfdee7c3b73e79))
+- *(package)* Handle replaced pkg_id - ([61a47fb](https://github.com/pkgforge/soar/commit/61a47fb0aa52e47719c845e21d94e524fa26466e))
+
 ## [0.1.10](https://github.com/pkgforge/soar/compare/soar-core-v0.1.9...soar-core-v0.1.10) - 2025-03-01
 
 ### ⛰️  Features

--- a/soar-core/Cargo.toml
+++ b/soar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-core"
-version = "0.1.10"
+version = "0.2.0"
 description = "Core library for soar package manager"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `soar-core`: 0.1.10 -> 0.2.0 (⚠ API breaking changes)
* `soar-cli`: 0.5.12 -> 0.5.13

### ⚠ `soar-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.install_excludes in /tmp/.tmp1UBa3z/soar/soar-core/src/config.rs:152
  field RemotePackage.replaces in /tmp/.tmp1UBa3z/soar/soar-core/src/database/models.rs:385
  field InstalledPackage.install_excludes in /tmp/.tmp1UBa3z/soar/soar-core/src/database/models.rs:186
  field Package.replaces in /tmp/.tmp1UBa3z/soar/soar-core/src/database/models.rs:79

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_missing.ron

Failed in:
  function soar_core::utils::process_broken_symlinks, previously in file /tmp/.tmp2K9gbH/soar-core/src/utils.rs:199

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_parameter_count_changed.ron

Failed in:
  soar_core::package::formats::common::symlink_icon now takes 1 parameters instead of 2, in /tmp/.tmp1UBa3z/soar/soar-core/src/package/formats/common.rs:64

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_parameter_count_changed.ron

Failed in:
  soar_core::database::repository::PackageRepository::import_packages now takes 2 parameters instead of 3, in /tmp/.tmp1UBa3z/soar/soar-core/src/database/repository.rs:21
  soar_core::package::install::PackageInstaller::new now takes 6 parameters instead of 5, in /tmp/.tmp1UBa3z/soar/soar-core/src/package/install.rs:45
  soar_core::package::install::PackageInstaller::record now takes 6 parameters instead of 9, in /tmp/.tmp1UBa3z/soar/soar-core/src/package/install.rs:171
  soar_core::database::connection::Database::from_remote_metadata now takes 3 parameters instead of 4, in /tmp/.tmp1UBa3z/soar/soar-core/src/database/connection.rs:45

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  soar_core::package::install::PackageInstaller::record takes 0 generic types instead of 1, in /tmp/.tmp1UBa3z/soar/soar-core/src/package/install.rs:171

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field bin_path of struct InstalledPackage, previously in file /tmp/.tmp2K9gbH/soar-core/src/database/models.rs:178
  field icon_path of struct InstalledPackage, previously in file /tmp/.tmp2K9gbH/soar-core/src/database/models.rs:179
  field desktop_path of struct InstalledPackage, previously in file /tmp/.tmp2K9gbH/soar-core/src/database/models.rs:180
  field appstream_path of struct InstalledPackage, previously in file /tmp/.tmp2K9gbH/soar-core/src/database/models.rs:181

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_method_missing.ron

Failed in:
  method icon of trait PackageExt, previously in file /tmp/.tmp2K9gbH/soar-core/src/database/models.rs:28
  method desktop of trait PackageExt, previously in file /tmp/.tmp2K9gbH/soar-core/src/database/models.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `soar-core`

<blockquote>

## [0.2.0](https://github.com/pkgforge/soar/compare/soar-core-v0.1.10...soar-core-v0.2.0) - 2025-03-10

### ⛰️  Features

- *(install)* Add partial support for excluding files on install - ([f496bf5](https://github.com/pkgforge/soar/commit/f496bf5f67dc9c71fab1c61d53e33f8047cab862))
- *(package)* Track excluded package installation files - ([a7ca6c0](https://github.com/pkgforge/soar/commit/a7ca6c01301784cf6f06c3a31b6bf47f174f39df))
- *(package)* Handle multiple desktop/icon integration - ([c5b6e4a](https://github.com/pkgforge/soar/commit/c5b6e4aeb8235372b77281b532dfdee7c3b73e79))
- *(package)* Handle replaced pkg_id - ([61a47fb](https://github.com/pkgforge/soar/commit/61a47fb0aa52e47719c845e21d94e524fa26466e))
</blockquote>

## `soar-cli`

<blockquote>

## [0.5.13](https://github.com/pkgforge/soar/compare/v0.5.12...v0.5.13) - 2025-03-10

### ⛰️  Features

- *(health)* Check if bin is in PATH - ([2c06017](https://github.com/pkgforge/soar/commit/2c06017a11e409b9207d55d86292e984ab105715))
- *(install)* Add partial support for excluding files on install - ([f496bf5](https://github.com/pkgforge/soar/commit/f496bf5f67dc9c71fab1c61d53e33f8047cab862))
- *(package)* Track excluded package installation files - ([a7ca6c0](https://github.com/pkgforge/soar/commit/a7ca6c01301784cf6f06c3a31b6bf47f174f39df))
- *(package)* Handle multiple desktop/icon integration - ([c5b6e4a](https://github.com/pkgforge/soar/commit/c5b6e4aeb8235372b77281b532dfdee7c3b73e79))
- *(package)* Handle replaced pkg_id - ([61a47fb](https://github.com/pkgforge/soar/commit/61a47fb0aa52e47719c845e21d94e524fa26466e))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).