### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 
+## [0.5.14](https://github.com/pkgforge/soar/compare/v0.5.13...v0.5.14) - 2025-03-22
+
+### ⛰️  Features
+
+- *(install)* Show installed path and symlinks - ([ab22401](https://github.com/pkgforge/soar/commit/ab22401832b9855ca8edbfb3b1df38636d2bb380))
+
+### 🐛 Bug Fixes
+
+- *(clean)* Remove package entirely on clean broken package - ([03d67be](https://github.com/pkgforge/soar/commit/03d67be974c9bade1bad6ec3a5f124d31473eb7f))
+- *(clippy)* Apply clippy suggestions - ([0be9c71](https://github.com/pkgforge/soar/commit/0be9c71c4e3c9917ea35c92bc02a2a1b4a98cf33))
+- *(fs)* Remove filtering from process_dir, delegate to caller - ([e60139b](https://github.com/pkgforge/soar/commit/e60139bc5dafbcfd485df102d1feda57faae4393))
+- *(integration)* Fix check for no desktop integration note - ([1344248](https://github.com/pkgforge/soar/commit/1344248942d87dae379fcac84de631978d29f95b))
+
 ## [0.5.13](https://github.com/pkgforge/soar/compare/v0.5.12...v0.5.13) - 2025-03-10
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "soar-cli"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "clap",
  "futures",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "soar-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/soar-cli/Cargo.toml
+++ b/soar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-cli"
-version = "0.5.13"
+version = "0.5.14"
 description = "A modern package manager for Linux"
 default-run = "soar"
 authors.workspace = true
@@ -30,7 +30,7 @@ rusqlite = { workspace = true }
 semver = "1.0.25"
 serde = { workspace = true }
 serde_json = { workspace = true }
-soar-core = { version = "0.2.0", path = "../soar-core" }
+soar-core = { version = "0.3.0", path = "../soar-core" }
 soar-dl = { workspace = true }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.8.20"

--- a/soar-core/CHANGELOG.md
+++ b/soar-core/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [0.3.0](https://github.com/pkgforge/soar/compare/soar-core-v0.2.0...soar-core-v0.3.0) - 2025-03-22
+
+### 🐛 Bug Fixes
+
+- *(clippy)* Apply clippy suggestions - ([0be9c71](https://github.com/pkgforge/soar/commit/0be9c71c4e3c9917ea35c92bc02a2a1b4a98cf33))
+- *(fs)* Remove filtering from process_dir, delegate to caller - ([e60139b](https://github.com/pkgforge/soar/commit/e60139bc5dafbcfd485df102d1feda57faae4393))
+
 ## [0.2.0](https://github.com/pkgforge/soar/compare/soar-core-v0.1.10...soar-core-v0.2.0) - 2025-03-10
 
 ### ⛰️  Features

--- a/soar-core/Cargo.toml
+++ b/soar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "Core library for soar package manager"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `soar-core`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `soar-cli`: 0.5.13 -> 0.5.14

### ⚠ `soar-core` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_parameter_count_changed.ron

Failed in:
  soar_core::utils::process_dir now takes 2 parameters instead of 3, in /tmp/.tmpkomn0c/soar/soar-core/src/utils.rs:199
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `soar-core`

<blockquote>

## [0.3.0](https://github.com/pkgforge/soar/compare/soar-core-v0.2.0...soar-core-v0.3.0) - 2025-03-22

### 🐛 Bug Fixes

- *(clippy)* Apply clippy suggestions - ([0be9c71](https://github.com/pkgforge/soar/commit/0be9c71c4e3c9917ea35c92bc02a2a1b4a98cf33))
- *(fs)* Remove filtering from process_dir, delegate to caller - ([e60139b](https://github.com/pkgforge/soar/commit/e60139bc5dafbcfd485df102d1feda57faae4393))
</blockquote>

## `soar-cli`

<blockquote>

## [0.5.14](https://github.com/pkgforge/soar/compare/v0.5.13...v0.5.14) - 2025-03-22

### ⛰️  Features

- *(install)* Show installed path and symlinks - ([ab22401](https://github.com/pkgforge/soar/commit/ab22401832b9855ca8edbfb3b1df38636d2bb380))

### 🐛 Bug Fixes

- *(clean)* Remove package entirely on clean broken package - ([03d67be](https://github.com/pkgforge/soar/commit/03d67be974c9bade1bad6ec3a5f124d31473eb7f))
- *(clippy)* Apply clippy suggestions - ([0be9c71](https://github.com/pkgforge/soar/commit/0be9c71c4e3c9917ea35c92bc02a2a1b4a98cf33))
- *(fs)* Remove filtering from process_dir, delegate to caller - ([e60139b](https://github.com/pkgforge/soar/commit/e60139bc5dafbcfd485df102d1feda57faae4393))
- *(integration)* Fix check for no desktop integration note - ([1344248](https://github.com/pkgforge/soar/commit/1344248942d87dae379fcac84de631978d29f95b))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).