### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.6.2](https://github.com/pkgforge/soar/compare/v0.6.1...v0.6.2) - 2025-06-03
+
+### 🚜 Refactor
+
+- *(checksum)* Save checksum from metadata as is for installed package - ([55b1f34](https://github.com/pkgforge/soar/commit/55b1f34911543743f52d92fd5618d1e47134896c))
+
 ## [0.6.1](https://github.com/pkgforge/soar/compare/v0.6.0...v0.6.1) - 2025-06-02
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,7 +2072,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "soar-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "futures",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "soar-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/soar-cli/Cargo.toml
+++ b/soar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-cli"
-version = "0.6.1"
+version = "0.6.2"
 description = "A modern package manager for Linux"
 default-run = "soar"
 authors.workspace = true
@@ -30,7 +30,7 @@ rusqlite = { workspace = true }
 semver = "1.0.26"
 serde = { workspace = true }
 serde_json = { workspace = true }
-soar-core = { version = "0.3.3", path = "../soar-core" }
+soar-core = { version = "0.4.0", path = "../soar-core" }
 soar-dl = { workspace = true }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 toml = "0.8.22"

--- a/soar-core/CHANGELOG.md
+++ b/soar-core/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.4.0](https://github.com/pkgforge/soar/compare/soar-core-v0.3.3...soar-core-v0.4.0) - 2025-06-03
+
+### 🚜 Refactor
+
+- *(checksum)* Save checksum from metadata as is for installed package - ([55b1f34](https://github.com/pkgforge/soar/commit/55b1f34911543743f52d92fd5618d1e47134896c))
+
 ## [0.3.3](https://github.com/pkgforge/soar/compare/soar-core-v0.3.2...soar-core-v0.3.3) - 2025-06-02
 
 ### 🐛 Bug Fixes

--- a/soar-core/Cargo.toml
+++ b/soar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-core"
-version = "0.3.3"
+version = "0.4.0"
 description = "Core library for soar package manager"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `soar-core`: 0.3.3 -> 0.4.0 (⚠ API breaking changes)
* `soar-cli`: 0.6.1 -> 0.6.2

### ⚠ `soar-core` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  soar_core::package::install::PackageInstaller::record now takes 6 parameters instead of 7, in /tmp/.tmpyhIflN/soar/soar-core/src/package/install.rs:199
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `soar-core`

<blockquote>

## [0.4.0](https://github.com/pkgforge/soar/compare/soar-core-v0.3.3...soar-core-v0.4.0) - 2025-06-03

### 🚜 Refactor

- *(checksum)* Save checksum from metadata as is for installed package - ([55b1f34](https://github.com/pkgforge/soar/commit/55b1f34911543743f52d92fd5618d1e47134896c))
</blockquote>

## `soar-cli`

<blockquote>

## [0.6.2](https://github.com/pkgforge/soar/compare/v0.6.1...v0.6.2) - 2025-06-03

### 🚜 Refactor

- *(checksum)* Save checksum from metadata as is for installed package - ([55b1f34](https://github.com/pkgforge/soar/commit/55b1f34911543743f52d92fd5618d1e47134896c))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).