### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 
+## [0.11.0](https://github.com/pkgforge/soar/compare/v0.10.3...v0.11.0) - 2026-02-04
+
+### ⛰️  Features
+
+- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
+- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
+- *(self)* Add release notes display and improve update UX - ([e63648c](https://github.com/pkgforge/soar/commit/e63648c0ded70e694a89ab16a65c10649692adf7))
+
+### 🐛 Bug Fixes
+
+- *(config)* Fix default repositories detection - ([22c121e](https://github.com/pkgforge/soar/commit/22c121ed2f134274a1edca9a174a4efa076b91c9))
+
+### 🚜 Refactor
+
+- *(config)* Remove --external flag - ([3b53b8b](https://github.com/pkgforge/soar/commit/3b53b8bd91e322df21f7e4466f7d7640330fb613))
+
 ## [0.10.3](https://github.com/pkgforge/soar/compare/v0.10.2...v0.10.3) - 2026-01-24
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,7 +2211,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soar-cli"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "clap",
  "fast-glob",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "soar-config"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "documented",
  "miette",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "soar-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "compak",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "soar-db"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "soar-dl"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "compak",
  "fast-glob",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "soar-package"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "image",
  "miette",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "soar-registry"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "miette",
  "serde",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "soar-utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ regex = { version = "1.12.2", default-features = false, features = [
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", features = ["indexmap"] }
 serial_test = "3.3.1"
-soar-config = { version = "0.4.0", path = "crates/soar-config" }
-soar-core = { version = "0.12.0", path = "crates/soar-core" }
-soar-db = { version = "0.3.2", path = "crates/soar-db" }
-soar-dl = { version = "0.7.3", path = "crates/soar-dl" }
-soar-package = { version = "0.2.2", path = "crates/soar-package" }
-soar-registry = { version = "0.2.2", path = "crates/soar-registry" }
-soar-utils = { version = "0.2.0", path = "crates/soar-utils" }
+soar-config = { version = "0.5.0", path = "crates/soar-config" }
+soar-core = { version = "0.13.0", path = "crates/soar-core" }
+soar-db = { version = "0.4.0", path = "crates/soar-db" }
+soar-dl = { version = "0.8.0", path = "crates/soar-dl" }
+soar-package = { version = "0.2.3", path = "crates/soar-package" }
+soar-registry = { version = "0.3.0", path = "crates/soar-registry" }
+soar-utils = { version = "0.3.0", path = "crates/soar-utils" }
 squishy = { version = "0.4.0", features = ["appimage", "dwarfs"] }
 tempfile = "3.24.0"
 thiserror = "2.0.17"

--- a/crates/soar-cli/Cargo.toml
+++ b/crates/soar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-cli"
-version = "0.10.3"
+version = "0.11.0"
 description = "A modern package manager for Linux"
 default-run = "soar"
 authors.workspace = true

--- a/crates/soar-config/CHANGELOG.md
+++ b/crates/soar-config/CHANGELOG.md
@@ -1,4 +1,19 @@
 
+## [0.5.0](https://github.com/pkgforge/soar/compare/soar-config-v0.4.0...soar-config-v0.5.0) - 2026-02-04
+
+### ⛰️  Features
+
+- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
+- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
+
+### 🐛 Bug Fixes
+
+- *(config)* Fix default repositories detection - ([22c121e](https://github.com/pkgforge/soar/commit/22c121ed2f134274a1edca9a174a4efa076b91c9))
+
+### 🚜 Refactor
+
+- *(config)* Remove --external flag - ([3b53b8b](https://github.com/pkgforge/soar/commit/3b53b8bd91e322df21f7e4466f7d7640330fb613))
+
 ## [0.4.0](https://github.com/pkgforge/soar/compare/soar-config-v0.3.0...soar-config-v0.4.0) - 2026-01-24
 
 ### ⛰️  Features

--- a/crates/soar-config/Cargo.toml
+++ b/crates/soar-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-config"
-version = "0.4.0"
+version = "0.5.0"
 description = "Configuration management for soar package manager"
 authors.workspace = true
 edition.workspace = true

--- a/crates/soar-core/CHANGELOG.md
+++ b/crates/soar-core/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [0.13.0](https://github.com/pkgforge/soar/compare/soar-core-v0.12.0...soar-core-v0.13.0) - 2026-02-04
+
+### ⛰️  Features
+
+- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
+- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
+
 ## [0.12.0](https://github.com/pkgforge/soar/compare/soar-core-v0.11.1...soar-core-v0.12.0) - 2026-01-24
 
 ### ⛰️  Features

--- a/crates/soar-core/Cargo.toml
+++ b/crates/soar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-core"
-version = "0.12.0"
+version = "0.13.0"
 description = "Core library for soar package manager"
 authors.workspace = true
 license.workspace = true

--- a/crates/soar-db/CHANGELOG.md
+++ b/crates/soar-db/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.4.0](https://github.com/pkgforge/soar/compare/soar-db-v0.3.2...soar-db-v0.4.0) - 2026-02-04
+
+### ⛰️  Features
+
+- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
+
 ## [0.3.2](https://github.com/pkgforge/soar/compare/soar-db-v0.3.1...soar-db-v0.3.2) - 2026-01-24
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-db/Cargo.toml
+++ b/crates/soar-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-db"
-version = "0.3.2"
+version = "0.4.0"
 description = "Database operations for soar package manager"
 authors.workspace = true
 license.workspace = true

--- a/crates/soar-dl/CHANGELOG.md
+++ b/crates/soar-dl/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.8.0](https://github.com/pkgforge/soar/compare/soar-dl-v0.7.3...soar-dl-v0.8.0) - 2026-02-04
+
+### ⛰️  Features
+
+- *(self)* Add release notes display and improve update UX - ([e63648c](https://github.com/pkgforge/soar/commit/e63648c0ded70e694a89ab16a65c10649692adf7))
+
 ## [0.7.3](https://github.com/pkgforge/soar/compare/soar-dl-v0.7.2...soar-dl-v0.7.3) - 2026-01-24
 
 ### ⛰️  Features

--- a/crates/soar-dl/Cargo.toml
+++ b/crates/soar-dl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-dl"
-version = "0.7.3"
+version = "0.8.0"
 description = "Downloader for soar package manager"
 authors.workspace = true
 license.workspace = true

--- a/crates/soar-package/CHANGELOG.md
+++ b/crates/soar-package/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.2.3](https://github.com/pkgforge/soar/compare/soar-package-v0.2.2...soar-package-v0.2.3) - 2026-02-04
+
+### ⛰️  Features
+
+- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
+
 ## [0.2.2](https://github.com/pkgforge/soar/compare/soar-package-v0.2.1...soar-package-v0.2.2) - 2026-01-24
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-package/Cargo.toml
+++ b/crates/soar-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-package"
-version = "0.2.2"
+version = "0.2.3"
 description = "Package format handling for soar package manager"
 authors.workspace = true
 edition.workspace = true

--- a/crates/soar-registry/CHANGELOG.md
+++ b/crates/soar-registry/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.3.0](https://github.com/pkgforge/soar/compare/soar-registry-v0.2.2...soar-registry-v0.3.0) - 2026-02-04
+
+### ⛰️  Features
+
+- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
+
 ## [0.2.2](https://github.com/pkgforge/soar/compare/soar-registry-v0.2.1...soar-registry-v0.2.2) - 2026-01-24
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-registry/Cargo.toml
+++ b/crates/soar-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-registry"
-version = "0.2.2"
+version = "0.3.0"
 description = "Registry management for soar package manager"
 authors.workspace = true
 edition.workspace = true

--- a/crates/soar-utils/CHANGELOG.md
+++ b/crates/soar-utils/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.3.0](https://github.com/pkgforge/soar/compare/soar-utils-v0.2.0...soar-utils-v0.3.0) - 2026-02-04
+
+### ⛰️  Features
+
+- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
+
 ## [0.2.0](https://github.com/pkgforge/soar/compare/soar-utils-v0.1.1...soar-utils-v0.2.0) - 2026-01-17
 
 ### ⛰️  Features

--- a/crates/soar-utils/Cargo.toml
+++ b/crates/soar-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-utils"
-version = "0.2.0"
+version = "0.3.0"
 description = "Utilities for soar package manager"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `soar-utils`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `soar-config`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `soar-dl`: 0.7.3 -> 0.8.0 (⚠ API breaking changes)
* `soar-registry`: 0.2.2 -> 0.3.0 (⚠ API breaking changes)
* `soar-db`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)
* `soar-package`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `soar-core`: 0.12.0 -> 0.13.0 (⚠ API breaking changes)
* `soar-cli`: 0.10.3 -> 0.11.0

### ⚠ `soar-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.desktop_path in /tmp/.tmpdREuck/soar/crates/soar-config/src/config.rs:52

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ConfigError::InvalidRepositoryNameStartsWithNest, previously in file /tmp/.tmpJq1NuS/soar-config/src/error.rs:90

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  soar_config::config::generate_default_config now takes 1 parameters instead of 2, in /tmp/.tmpdREuck/soar/crates/soar-config/src/config.rs:494

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Config::get_nests_sync_interval, previously in file /tmp/.tmpJq1NuS/soar-config/src/config.rs:428

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  soar_config::config::Config::default_config now takes 1 parameters instead of 2, in /tmp/.tmpdREuck/soar/crates/soar-config/src/config.rs:176

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field nests_sync_interval of struct Config, previously in file /tmp/.tmpJq1NuS/soar-config/src/config.rs:93
  field is_core of struct DefaultRepositoryInfo, previously in file /tmp/.tmpJq1NuS/soar-config/src/repository.rs:84
```

### ⚠ `soar-dl` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GitLabRelease.description in /tmp/.tmpdREuck/soar/crates/soar-dl/src/gitlab.rs:17
  field GithubRelease.body in /tmp/.tmpdREuck/soar/crates/soar-dl/src/github.rs:17

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method soar_dl::traits::Release::body in file /tmp/.tmpdREuck/soar/crates/soar-dl/src/traits.rs:16
```

### ⚠ `soar-registry` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function soar_registry::metadata::fetch_nest_metadata, previously in file /tmp/.tmpJq1NuS/soar-registry/src/metadata.rs:89
  function soar_registry::fetch_nest_metadata, previously in file /tmp/.tmpJq1NuS/soar-registry/src/metadata.rs:89

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod soar_registry::nest, previously in file /tmp/.tmpJq1NuS/soar-registry/src/nest.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct soar_registry::nest::Nest, previously in file /tmp/.tmpJq1NuS/soar-registry/src/nest.rs:20
  struct soar_registry::Nest, previously in file /tmp/.tmpJq1NuS/soar-registry/src/nest.rs:20
```

### ⚠ `soar-db` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant DbType::Nest, previously in file /tmp/.tmpJq1NuS/soar-db/src/migration.rs:14

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  DatabaseManager::nests, previously in file /tmp/.tmpJq1NuS/soar-db/src/connection.rs:236

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod soar_db::schema::nest::nests, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  mod soar_db::repository::nest, previously in file /tmp/.tmpJq1NuS/soar-db/src/repository/nest.rs:1
  mod soar_db::schema::nest, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  mod soar_db::schema::nest::nests::columns, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  mod soar_db::models::nest, previously in file /tmp/.tmpJq1NuS/soar-db/src/models/nest.rs:1
  mod soar_db::schema::nest::nests::dsl, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  all_columns in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  NEST_MIGRATIONS in file /tmp/.tmpJq1NuS/soar-db/src/migration.rs:8

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct soar_db::schema::nest::nests::dsl::id, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::columns::id, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::id, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::columns::star, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::star, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::dsl::name, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::columns::name, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::name, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::models::nest::NewNest, previously in file /tmp/.tmpJq1NuS/soar-db/src/models/nest.rs:16
  struct soar_db::schema::nest::nests::dsl::nests, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::table, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::models::nest::Nest, previously in file /tmp/.tmpJq1NuS/soar-db/src/models/nest.rs:8
  struct soar_db::repository::nest::NestRepository, previously in file /tmp/.tmpJq1NuS/soar-db/src/repository/nest.rs:11
  struct soar_db::schema::nest::nests::dsl::url, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::columns::url, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
  struct soar_db::schema::nest::nests::url, previously in file /tmp/.tmpJq1NuS/soar-db/src/schema/nest.rs:1
```

### ⚠ `soar-core` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function soar_core::utils::get_nests_db_conn, previously in file /tmp/.tmpJq1NuS/soar-core/src/utils.rs:115

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  DieselDatabase::open_nests, previously in file /tmp/.tmpJq1NuS/soar-core/src/database/connection.rs:42
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `soar-utils`

<blockquote>

## [0.3.0](https://github.com/pkgforge/soar/compare/soar-utils-v0.2.0...soar-utils-v0.3.0) - 2026-02-04

### ⛰️  Features

- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
</blockquote>

## `soar-config`

<blockquote>

## [0.5.0](https://github.com/pkgforge/soar/compare/soar-config-v0.4.0...soar-config-v0.5.0) - 2026-02-04

### ⛰️  Features

- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))

### 🐛 Bug Fixes

- *(config)* Fix default repositories detection - ([22c121e](https://github.com/pkgforge/soar/commit/22c121ed2f134274a1edca9a174a4efa076b91c9))

### 🚜 Refactor

- *(config)* Remove --external flag - ([3b53b8b](https://github.com/pkgforge/soar/commit/3b53b8bd91e322df21f7e4466f7d7640330fb613))
</blockquote>

## `soar-dl`

<blockquote>

## [0.8.0](https://github.com/pkgforge/soar/compare/soar-dl-v0.7.3...soar-dl-v0.8.0) - 2026-02-04

### ⛰️  Features

- *(self)* Add release notes display and improve update UX - ([e63648c](https://github.com/pkgforge/soar/commit/e63648c0ded70e694a89ab16a65c10649692adf7))
</blockquote>

## `soar-registry`

<blockquote>

## [0.3.0](https://github.com/pkgforge/soar/compare/soar-registry-v0.2.2...soar-registry-v0.3.0) - 2026-02-04

### ⛰️  Features

- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
</blockquote>

## `soar-db`

<blockquote>

## [0.4.0](https://github.com/pkgforge/soar/compare/soar-db-v0.3.2...soar-db-v0.4.0) - 2026-02-04

### ⛰️  Features

- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
</blockquote>

## `soar-package`

<blockquote>

## [0.2.3](https://github.com/pkgforge/soar/compare/soar-package-v0.2.2...soar-package-v0.2.3) - 2026-02-04

### ⛰️  Features

- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
</blockquote>

## `soar-core`

<blockquote>

## [0.13.0](https://github.com/pkgforge/soar/compare/soar-core-v0.12.0...soar-core-v0.13.0) - 2026-02-04

### ⛰️  Features

- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
</blockquote>

## `soar-cli`

<blockquote>

## [0.11.0](https://github.com/pkgforge/soar/compare/v0.10.3...v0.11.0) - 2026-02-04

### ⛰️  Features

- *(config)* Allow setting path for desktop files - ([50c0335](https://github.com/pkgforge/soar/commit/50c033592d5611f4a982c20c45a0242b4826e93d))
- *(nest)* [**breaking**] Remove nest functionality - ([dc21853](https://github.com/pkgforge/soar/commit/dc21853a2506d93d5ade9e2c4015c3a12b24c199))
- *(self)* Add release notes display and improve update UX - ([e63648c](https://github.com/pkgforge/soar/commit/e63648c0ded70e694a89ab16a65c10649692adf7))

### 🐛 Bug Fixes

- *(config)* Fix default repositories detection - ([22c121e](https://github.com/pkgforge/soar/commit/22c121ed2f134274a1edca9a174a4efa076b91c9))

### 🚜 Refactor

- *(config)* Remove --external flag - ([3b53b8b](https://github.com/pkgforge/soar/commit/3b53b8bd91e322df21f7e4466f7d7640330fb613))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for configuring desktop file paths
  * Release notes display functionality
  * Improved update experience

* **Bug Fixes**
  * Fixed default repository detection

* **Breaking Changes**
  * Removed nest functionality
  * Removed --external flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->