### PR TITLE
feat(lock): add locking for concurrent process safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ image = { version = "0.25.9", default-features = false, features = ["png"] }
 landlock = "0.4.4"
 libsqlite3-sys = { version = ">=0.30.1,<0.36.0", features = [ "bundled" ]}
 miette = { version = "7.6.0", features = ["fancy"] }
-nix = { version = "0.30.1", features = ["ioctl", "term", "user"] }
+nix = { version = "0.30.1", features = ["fs", "ioctl", "term", "user"] }
 percent-encoding = "2.3.2"
 rayon = "1.11.0"
 regex = { version = "1.12.2", default-features = false, features = [

--- a/crates/soar-utils/src/error.rs
+++ b/crates/soar-utils/src/error.rs
@@ -31,6 +31,24 @@ pub enum HashError {
     },
 }
 
+/// Errors that can occur when working with locks.
+#[derive(Debug, Diagnostic, Error)]
+pub enum LockError {
+    #[error(transparent)]
+    #[diagnostic(
+        code(soar_utils::lock::io),
+        help("Check if you have write permissions to the lock directory")
+    )]
+    Io(#[from] std::io::Error),
+
+    #[error("Failed to acquire lock for '{0}'")]
+    #[diagnostic(
+        code(soar_utils::lock::acquire_failed),
+        help("Check if the lock directory exists and you have write permissions")
+    )]
+    AcquireFailed(String),
+}
+
 /// Error type for path operations.
 #[derive(Error, Diagnostic, Debug)]
 pub enum PathError {
@@ -362,6 +380,10 @@ pub enum UtilsError {
 
     #[error(transparent)]
     #[diagnostic(transparent)]
+    Lock(#[from] LockError),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
     Path(#[from] PathError),
 
     #[error(transparent)]
@@ -376,6 +398,7 @@ pub enum UtilsError {
 pub type BytesResult<T> = std::result::Result<T, BytesError>;
 pub type FileSystemResult<T> = std::result::Result<T, FileSystemError>;
 pub type HashResult<T> = std::result::Result<T, HashError>;
+pub type LockResult<T> = std::result::Result<T, LockError>;
 pub type PathResult<T> = std::result::Result<T, PathError>;
 pub type UtilsResult<T> = std::result::Result<T, UtilsError>;
 

--- a/crates/soar-utils/src/fs.rs
+++ b/crates/soar-utils/src/fs.rs
@@ -40,7 +40,7 @@ pub fn safe_remove<P: AsRef<Path>>(path: P) -> FileSystemResult<()> {
             return Err(FileSystemError::RemoveFile {
                 path: path.to_path_buf(),
                 source: e,
-            })
+            });
         }
     };
 

--- a/crates/soar-utils/src/lib.rs
+++ b/crates/soar-utils/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bytes;
 pub mod error;
 pub mod fs;
 pub mod hash;
+pub mod lock;
 pub mod path;
 pub mod pattern;
 pub mod system;

--- a/crates/soar-utils/src/lock.rs
+++ b/crates/soar-utils/src/lock.rs
@@ -1,0 +1,193 @@
+//! File-based locking mechanism for preventing concurrent operations.
+//!
+//! This module provides a simple file-based lock using a `.lock` file to ensure
+//! that only one process can operate on a specific resource at a time.
+
+use std::{
+    fs::{self, File, OpenOptions},
+    path::{Path, PathBuf},
+};
+
+use crate::error::{LockError, LockResult};
+
+/// A file-based lock using `flock`.
+///
+/// The lock is automatically released when `FileLock` is dropped.
+pub struct FileLock {
+    _file: nix::fcntl::Flock<File>,
+    path: PathBuf,
+}
+
+impl FileLock {
+    /// Get the default lock directory for soar.
+    ///
+    /// Uses `$XDG_RUNTIME_DIR/soar/locks` or falls back to `/tmp/soar-locks`.
+    fn lock_dir() -> LockResult<PathBuf> {
+        let xdg_runtime = std::env::var("XDG_RUNTIME_DIR").ok();
+        let base = if let Some(ref runtime) = xdg_runtime {
+            PathBuf::from(runtime)
+        } else {
+            std::env::temp_dir()
+        };
+
+        let lock_dir = base.join("soar").join("locks");
+
+        if !lock_dir.exists() {
+            fs::create_dir_all(&lock_dir)?;
+        }
+
+        Ok(lock_dir)
+    }
+
+    /// Generate a lock file path for a package.
+    fn lock_path(name: &str) -> LockResult<PathBuf> {
+        let lock_dir = Self::lock_dir()?;
+
+        // Sanitize the package name to ensure a valid filename
+        let sanitize = |s: &str| {
+            s.chars()
+                .map(|c| {
+                    if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect::<String>()
+        };
+
+        let filename = format!("{}.lock", sanitize(name));
+        Ok(lock_dir.join(filename))
+    }
+
+    /// Acquire an exclusive lock on a package.
+    ///
+    /// This will block until the lock can be acquired.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Package name
+    ///
+    /// # Returns
+    ///
+    /// Returns a `FileLock` that will automatically release the lock when dropped.
+    pub fn acquire(name: &str) -> LockResult<Self> {
+        let lock_path = Self::lock_path(name)?;
+
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+
+        let file = nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusive).map_err(
+            |(_, err)| LockError::AcquireFailed(format!("{}: {}", lock_path.display(), err)),
+        )?;
+
+        Ok(FileLock {
+            path: lock_path,
+            _file: file,
+        })
+    }
+
+    /// Try to acquire an exclusive lock without blocking.
+    ///
+    /// Returns `None` if the lock is already held by another process.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Package name
+    pub fn try_acquire(name: &str) -> LockResult<Option<Self>> {
+        let lock_path = Self::lock_path(name)?;
+
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+
+        match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+            Ok(file) => {
+                Ok(Some(FileLock {
+                    path: lock_path,
+                    _file: file,
+                }))
+            }
+            Err((_, err)) => {
+                if matches!(err, nix::errno::Errno::EWOULDBLOCK) {
+                    return Ok(None);
+                }
+                Err(LockError::AcquireFailed(format!(
+                    "{}: {}",
+                    lock_path.display(),
+                    err
+                )))
+            }
+        }
+    }
+
+    /// Get the path to the lock file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{thread, time::Duration};
+
+    use super::*;
+
+    #[test]
+    fn test_lock_path_generation() {
+        let path = FileLock::lock_path("test-pkg").unwrap();
+        assert!(path.to_string_lossy().ends_with("test-pkg.lock"));
+    }
+
+    #[test]
+    fn test_lock_sanitization() {
+        let path = FileLock::lock_path("test/pkg").unwrap();
+        assert!(path.to_string_lossy().contains("test_pkg"));
+    }
+
+    #[test]
+    fn test_exclusive_lock() {
+        let lock1 = FileLock::acquire("test-exclusive").unwrap();
+
+        let lock2 = FileLock::try_acquire("test-exclusive").unwrap();
+        assert!(lock2.is_none(), "Should not be able to acquire lock");
+
+        drop(lock1);
+
+        let lock3 = FileLock::try_acquire("test-exclusive").unwrap();
+        assert!(
+            lock3.is_some(),
+            "Should be able to acquire lock after release"
+        );
+    }
+
+    #[test]
+    fn test_concurrent_locks_different_packages() {
+        let lock1 = FileLock::acquire("pkg-a").unwrap();
+        let lock2 = FileLock::acquire("pkg-b").unwrap();
+
+        assert!(lock1.path() != lock2.path());
+    }
+
+    #[test]
+    fn test_lock_blocks_until_released() {
+        let lock1 = FileLock::acquire("test-block").unwrap();
+        let path = lock1.path().to_path_buf();
+
+        let handle = thread::spawn(move || {
+            let lock2 = FileLock::acquire("test-block").unwrap();
+            assert_eq!(lock2.path(), &path);
+        });
+
+        thread::sleep(Duration::from_millis(100));
+
+        drop(lock1);
+
+        handle.join().unwrap();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-process file locking for package installation to prevent concurrent installs of the same package.

* **Bug Fixes**
  * Prevented double-installation and incorrect install counts during simultaneous installation attempts; installer now skips already-installed packages post-lock.

* **Chores**
  * Adjusted workspace dependency features to include filesystem locking support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->