### PR TITLE
fix(security): validate provides names to block path traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,7 @@ dependencies = [
  "soar-events",
  "soar-package",
  "soar-utils",
+ "tempfile",
  "thiserror",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -2341,6 +2342,7 @@ dependencies = [
  "soar-package",
  "soar-registry",
  "soar-utils",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/soar-core/Cargo.toml
+++ b/crates/soar-core/Cargo.toml
@@ -35,3 +35,6 @@ toml = { workspace = true }
 tracing = { workspace = true }
 ureq = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/soar-core/src/package/install.rs
+++ b/crates/soar-core/src/package/install.rs
@@ -36,7 +36,7 @@ use crate::{
     constants::INSTALL_MARKER_FILE,
     database::{connection::DieselDatabase, models::Package},
     error::{ErrorContext, SoarError},
-    package::local::local_path_from_url,
+    package::{local::local_path_from_url, remove::remove_provide_symlinks},
     utils::get_extract_dir,
     SoarResult,
 };
@@ -997,16 +997,7 @@ impl PackageInstaller {
 
                 if let Some(ref provides) = alt_pkg.provides {
                     let bin_path = self.config.get_bin_path()?;
-                    for provide in provides {
-                        for name in provide.bin_symlink_names() {
-                            let link = bin_path.join(name);
-                            if link.is_symlink() || link.is_file() {
-                                std::fs::remove_file(&link).with_context(|| {
-                                    format!("removing provide {}", link.display())
-                                })?;
-                            }
-                        }
-                    }
+                    remove_provide_symlinks(&bin_path, provides, &installed_path)?;
                 }
             }
         }

--- a/crates/soar-core/src/package/remove.rs
+++ b/crates/soar-core/src/package/remove.rs
@@ -8,11 +8,44 @@ use soar_config::{
     config::Config,
     packages::{PackageHooks, SandboxConfig},
 };
-use soar_db::repository::core::CoreRepository;
+use soar_db::{models::types::PackageProvide, repository::core::CoreRepository};
 use soar_utils::{error::FileSystemResult, fs::walk_dir};
 use tracing::{debug, trace, warn};
 
 use super::hooks::{run_hook, HookEnv};
+
+/// Removes the bin-directory symlinks a package's `provides` created, keeping
+/// only those that live directly in `bin_path` and resolve into
+/// `installed_path`.
+///
+/// Untrusted provide names could otherwise escape `bin_path` via path traversal
+/// or collide with another package's identically named symlink; both cases are
+/// skipped here. Returns the links that were actually removed.
+pub(crate) fn remove_provide_symlinks(
+    bin_path: &Path,
+    provides: &[PackageProvide],
+    installed_path: &Path,
+) -> SoarResult<Vec<PathBuf>> {
+    let mut removed = Vec::new();
+    for provide in provides {
+        for name in provide.bin_symlink_names() {
+            let link = bin_path.join(name);
+            if link.parent() != Some(bin_path) {
+                continue;
+            }
+            match fs::read_link(&link) {
+                Ok(target) if target.starts_with(installed_path) => {
+                    trace!("removing provide symlink: {}", link.display());
+                    fs::remove_file(&link)
+                        .with_context(|| format!("removing provide {}", link.display()))?;
+                    removed.push(link);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(removed)
+}
 
 /// Formats bytes into human-readable string (e.g., "1.5 MiB")
 fn format_size(bytes: u64) -> String {
@@ -121,19 +154,11 @@ impl PackageRemover {
         if self.package.is_installed {
             trace!("package was installed, removing binaries and links");
             let bin_path = self.config.get_bin_path()?;
+            let installed_path = PathBuf::from(&self.package.installed_path);
 
             if let Some(provides) = &self.package.provides {
-                for provide in provides {
-                    for name in provide.bin_symlink_names() {
-                        let link = bin_path.join(name);
-                        if link.is_symlink() || link.is_file() {
-                            trace!("removing provide symlink: {}", link.display());
-                            fs::remove_file(&link)
-                                .with_context(|| format!("removing provide {}", link.display()))?;
-                            removed_symlinks.push(link);
-                        }
-                    }
-                }
+                let removed = remove_provide_symlinks(&bin_path, provides, &installed_path)?;
+                removed_symlinks.extend(removed);
             } else {
                 let def_bin = bin_path.join(&self.package.pkg_name);
                 if def_bin.is_symlink() && def_bin.is_file() {
@@ -143,8 +168,6 @@ impl PackageRemover {
                     removed_symlinks.push(def_bin);
                 }
             }
-
-            let installed_path = PathBuf::from(&self.package.installed_path);
 
             let mut remove_action = |path: &Path| -> FileSystemResult<()> {
                 if path.extension() == Some(&OsString::from("desktop")) {
@@ -226,5 +249,91 @@ impl PackageRemover {
             size_str
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{self, File},
+        os::unix::fs::symlink,
+    };
+
+    use soar_db::models::types::PackageProvide;
+    use tempfile::tempdir;
+
+    use super::remove_provide_symlinks;
+
+    #[test]
+    fn removes_owned_provide_symlink() {
+        let install = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let target = install.path().join("clipcat");
+        File::create(&target).unwrap();
+        let link = bin.path().join("clipcat");
+        symlink(&target, &link).unwrap();
+
+        let provides = vec![PackageProvide::from_string("clipcat")];
+        let removed = remove_provide_symlinks(bin.path(), &provides, install.path()).unwrap();
+
+        assert_eq!(removed, vec![link.clone()]);
+        assert!(link.symlink_metadata().is_err());
+        assert!(target.exists(), "only the symlink should be removed");
+    }
+
+    #[test]
+    fn skips_symlink_owned_by_another_package() {
+        let install = tempdir().unwrap();
+        let other = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let other_target = other.path().join("clipcat");
+        File::create(&other_target).unwrap();
+        let link = bin.path().join("clipcat");
+        symlink(&other_target, &link).unwrap();
+
+        let provides = vec![PackageProvide::from_string("clipcat")];
+        let removed = remove_provide_symlinks(bin.path(), &provides, install.path()).unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            link.symlink_metadata().is_ok(),
+            "another package's link stays"
+        );
+    }
+
+    #[test]
+    fn skips_regular_file() {
+        let install = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let file = bin.path().join("clipcat");
+        File::create(&file).unwrap();
+
+        let provides = vec![PackageProvide::from_string("clipcat")];
+        let removed = remove_provide_symlinks(bin.path(), &provides, install.path()).unwrap();
+
+        assert!(removed.is_empty());
+        assert!(file.exists(), "a non-symlink file is never removed");
+    }
+
+    #[test]
+    fn rejects_path_traversal_in_provide_name() {
+        let root = tempdir().unwrap();
+        let bin = root.path().join("bin");
+        let install = root.path().join("install");
+        fs::create_dir_all(&bin).unwrap();
+        fs::create_dir_all(&install).unwrap();
+
+        // bin.join("../victim") resolves to root/victim, outside bin.
+        let victim = root.path().join("victim");
+        File::create(&victim).unwrap();
+
+        let provides = vec![PackageProvide::from_string("clipcat=>../victim")];
+        let removed = remove_provide_symlinks(&bin, &provides, &install).unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            victim.exists(),
+            "traversal must not touch files outside bin"
+        );
     }
 }

--- a/crates/soar-db/src/models/types.rs
+++ b/crates/soar-db/src/models/types.rs
@@ -1,4 +1,17 @@
+use std::path::{Component, Path};
+
 use serde::{Deserialize, Serialize};
+
+/// Returns `true` if `name` is a single, normal path component that is safe to
+/// join onto a directory.
+///
+/// Rejects empty strings, absolute paths, `.`/`..`, and any value containing a
+/// path separator. Used to keep untrusted `provides` metadata from escaping the
+/// bin directory when it is turned into a symlink path.
+pub fn is_safe_component(name: &str) -> bool {
+    let mut components = Path::new(name).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum ProvideStrategy {
@@ -41,6 +54,13 @@ impl PackageProvide {
             }
             _ => vec![&self.name],
         }
+    }
+
+    /// Returns `true` if the provide's name and target are safe single path
+    /// components, i.e. they cannot escape the bin directory when used as
+    /// symlink paths.
+    pub fn is_safe(&self) -> bool {
+        is_safe_component(&self.name) && self.target.as_deref().is_none_or(is_safe_component)
     }
 
     pub fn from_string(provide: &str) -> Self {
@@ -115,5 +135,31 @@ mod tests {
     fn test_bin_symlink_names_alias() {
         let p = PackageProvide::from_string("clipcatd:clipcat");
         assert_eq!(p.bin_symlink_names(), vec!["clipcat"]);
+    }
+
+    #[test]
+    fn test_is_safe_component() {
+        assert!(is_safe_component("clipcat"));
+        assert!(is_safe_component("clip-cat.1"));
+
+        assert!(!is_safe_component(""));
+        assert!(!is_safe_component("."));
+        assert!(!is_safe_component(".."));
+        assert!(!is_safe_component("a/b"));
+        assert!(!is_safe_component("../etc"));
+        assert!(!is_safe_component("../../home/user/.bashrc"));
+        assert!(!is_safe_component("/etc/passwd"));
+    }
+
+    #[test]
+    fn test_provide_is_safe() {
+        assert!(PackageProvide::from_string("clipcatd").is_safe());
+        assert!(PackageProvide::from_string("clipcatd==clipcat").is_safe());
+        assert!(PackageProvide::from_string("@clipcat-menu").is_safe());
+
+        assert!(!PackageProvide::from_string("clipcatd=>../../../../home/user/.bashrc").is_safe());
+        assert!(!PackageProvide::from_string("../evil").is_safe());
+        assert!(!PackageProvide::from_string("ok==../evil").is_safe());
+        assert!(!PackageProvide::from_string("@../evil").is_safe());
     }
 }

--- a/crates/soar-db/src/repository/metadata.rs
+++ b/crates/soar-db/src/repository/metadata.rs
@@ -6,7 +6,7 @@ use diesel::{dsl::sql, prelude::*, sql_types::Text};
 use regex::Regex;
 use serde_json::json;
 use soar_registry::RemotePackage;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 /// Regex for extracting name and contact from maintainer string format "Name (contact)".
 static MAINTAINER_RE: OnceLock<Regex> = OnceLock::new();
@@ -527,6 +527,18 @@ impl MetadataRepository {
         let provides = package.provides.as_ref().map(|vec| {
             vec.iter()
                 .map(|p| PackageProvide::from_string(p))
+                .filter(|provide| {
+                    let safe = provide.is_safe();
+                    if !safe {
+                        warn!(
+                            pkg_id = package.pkg_id,
+                            pkg_name = package.pkg_name,
+                            provide = provide.name,
+                            "skipping provide with unsafe path component"
+                        );
+                    }
+                    safe
+                })
                 .collect::<Vec<_>>()
         });
 

--- a/crates/soar-operations/Cargo.toml
+++ b/crates/soar-operations/Cargo.toml
@@ -25,3 +25,6 @@ soar-registry = { workspace = true }
 soar-utils = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/soar-operations/src/utils.rs
+++ b/crates/soar-operations/src/utils.rs
@@ -15,8 +15,9 @@ use soar_core::{
     utils::substitute_placeholders,
     SoarResult,
 };
-use soar_db::models::types::{PackageProvide, ProvideStrategy};
+use soar_db::models::types::PackageProvide;
 use soar_utils::fs::is_elf;
+use tracing::warn;
 
 /// Check if a package should have desktop integration (desktop files, icons).
 pub fn has_desktop_integration(package: &Package, config: &Config) -> bool {
@@ -39,6 +40,51 @@ pub fn get_package_hooks(pkg_name: &str) -> (Option<PackageHooks>, Option<Sandbo
         .find(|p| p.name == pkg_name)
         .map(|p| (p.hooks, p.sandbox))
         .unwrap_or((None, None))
+}
+
+/// Creates the bin-directory symlinks declared by a package's `provides`.
+///
+/// Provides whose name or target is not a safe single path component are skipped
+/// (see [`PackageProvide::is_safe`]) so untrusted metadata cannot escape
+/// `install_dir`/`bin_dir` when building symlink paths. Returns the created
+/// `(source, link)` pairs.
+fn create_provide_symlinks(
+    install_dir: &Path,
+    bin_dir: &Path,
+    provides: &[PackageProvide],
+) -> SoarResult<Vec<(PathBuf, PathBuf)>> {
+    let mut symlinks = Vec::new();
+    let mut processed_paths = HashSet::new();
+    for provide in provides {
+        if !provide.is_safe() {
+            warn!(
+                provide = provide.name,
+                "skipping provide with unsafe path component"
+            );
+            continue;
+        }
+        let real_path = install_dir.join(provide.name.clone());
+
+        for name in provide.bin_symlink_names() {
+            let target_path = bin_dir.join(name);
+            if !processed_paths.insert(target_path.clone()) {
+                continue;
+            }
+            if target_path.is_symlink() || target_path.is_file() {
+                std::fs::remove_file(&target_path)
+                    .with_context(|| format!("removing provide {}", target_path.display()))?;
+            }
+            unix::fs::symlink(&real_path, &target_path).with_context(|| {
+                format!(
+                    "creating symlink {} -> {}",
+                    real_path.display(),
+                    target_path.display()
+                )
+            })?;
+            symlinks.push((real_path.clone(), target_path));
+        }
+    }
+    Ok(symlinks)
 }
 
 /// Creates symlinks from installed package binaries to the bin directory.
@@ -114,54 +160,8 @@ pub async fn mangle_package_symlinks(
         }
     }
 
-    let mut processed_paths = HashSet::new();
     let provides = provides.unwrap_or_default();
-    for provide in provides {
-        let real_path = install_dir.join(provide.name.clone());
-        let mut symlink_targets = Vec::new();
-
-        if provide.symlink_to_bin {
-            let link_path = bin_dir.join(&provide.name);
-            if processed_paths.insert(link_path.clone()) {
-                symlink_targets.push(link_path);
-            }
-        } else if let Some(ref target) = provide.target {
-            if provide.strategy.is_some() {
-                let target_path = bin_dir.join(target);
-                if processed_paths.insert(target_path.clone()) {
-                    symlink_targets.push(target_path);
-                }
-            }
-        };
-
-        let needs_original_symlink = !provide.symlink_to_bin
-            && matches!(
-                (provide.target.as_ref(), provide.strategy.clone()),
-                (Some(_), Some(ProvideStrategy::KeepBoth)) | (None, _)
-            );
-
-        if needs_original_symlink {
-            let original_path = bin_dir.join(&provide.name);
-            if processed_paths.insert(original_path.clone()) {
-                symlink_targets.push(original_path);
-            }
-        }
-
-        for target_path in symlink_targets {
-            if target_path.is_symlink() || target_path.is_file() {
-                std::fs::remove_file(&target_path)
-                    .with_context(|| format!("removing provide {}", target_path.display()))?;
-            }
-            unix::fs::symlink(&real_path, &target_path).with_context(|| {
-                format!(
-                    "creating symlink {} -> {}",
-                    real_path.display(),
-                    target_path.display()
-                )
-            })?;
-            symlinks.push((real_path.clone(), target_path));
-        }
-    }
+    symlinks.extend(create_provide_symlinks(install_dir, bin_dir, provides)?);
 
     if provides.is_empty() {
         let soar_syms = install_dir.join("SOAR_SYMS");
@@ -326,4 +326,88 @@ fn find_matching_executable(
             })
         })
         .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{self, File},
+        path::PathBuf,
+    };
+
+    use soar_db::models::types::PackageProvide;
+    use tempfile::{tempdir, TempDir};
+
+    use super::create_provide_symlinks;
+
+    fn setup() -> (TempDir, PathBuf, PathBuf) {
+        let root = tempdir().unwrap();
+        let install = root.path().join("install");
+        let bin = root.path().join("bin");
+        fs::create_dir_all(&install).unwrap();
+        fs::create_dir_all(&bin).unwrap();
+        (root, install, bin)
+    }
+
+    fn is_symlink(path: &std::path::Path) -> bool {
+        path.symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn creates_symlink_for_plain_provide() {
+        let (_root, install, bin) = setup();
+        File::create(install.join("clipcat")).unwrap();
+
+        let provides = vec![PackageProvide::from_string("clipcat")];
+        let created = create_provide_symlinks(&install, &bin, &provides).unwrap();
+
+        let link = bin.join("clipcat");
+        assert_eq!(created, vec![(install.join("clipcat"), link.clone())]);
+        assert_eq!(fs::read_link(&link).unwrap(), install.join("clipcat"));
+    }
+
+    #[test]
+    fn creates_both_symlinks_for_keep_both() {
+        let (_root, install, bin) = setup();
+        File::create(install.join("clipcatd")).unwrap();
+
+        let provides = vec![PackageProvide::from_string("clipcatd==clipcat")];
+        let created = create_provide_symlinks(&install, &bin, &provides).unwrap();
+
+        assert_eq!(created.len(), 2);
+        assert!(is_symlink(&bin.join("clipcatd")));
+        assert!(is_symlink(&bin.join("clipcat")));
+    }
+
+    #[test]
+    fn skips_unsafe_target() {
+        let (root, install, bin) = setup();
+        // bin.join("../victim") resolves to root/victim, outside bin.
+        let victim = root.path().join("victim");
+        File::create(&victim).unwrap();
+
+        let provides = vec![PackageProvide::from_string("clipcat=>../victim")];
+        let created = create_provide_symlinks(&install, &bin, &provides).unwrap();
+
+        assert!(created.is_empty());
+        assert!(
+            victim.symlink_metadata().unwrap().file_type().is_file(),
+            "unsafe target must not be replaced by a symlink"
+        );
+    }
+
+    #[test]
+    fn skips_unsafe_symlink_to_bin_name() {
+        let (root, install, bin) = setup();
+        let victim = root.path().join("evil");
+        File::create(&victim).unwrap();
+
+        let provides = vec![PackageProvide::from_string("@../evil")];
+        let created = create_provide_symlinks(&install, &bin, &provides).unwrap();
+
+        assert!(created.is_empty());
+        assert!(victim.symlink_metadata().unwrap().file_type().is_file());
+    }
 }


### PR DESCRIPTION
Untrusted `provides` metadata was joined onto bin/install dirs verbatim, allowing arbitrary file deletion on remove and symlink planting on install. Validate names as single path components at import, and add ownership/containment checks at the remove and create sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Strengthened safeguards for package-provided binary symlinks during installation and removal.
  * Added validation to reject unsafe provide names/targets (e.g., path traversal/absolute paths), with warnings when skipped.
  * Prevented unrelated files or symlinks from being overwritten or removed.

* **Bug Fixes**
  * Improved cleanup to remove only symlinks that are owned by an installation, avoiding incorrect filesystem changes.

* **Tests**
  * Added unit test coverage for safe-path validation and provide symlink behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->