### PR TITLE
fix(security): validate pkg_name and pkg_id as path components

### DIFF
--- a/crates/soar-core/src/package/url.rs
+++ b/crates/soar-core/src/package/url.rs
@@ -3,6 +3,7 @@
 use std::sync::OnceLock;
 
 use regex::Regex;
+use soar_utils::path::is_safe_component;
 
 use crate::{database::models::Package, error::SoarError, SoarResult};
 
@@ -84,6 +85,27 @@ impl UrlPackage {
         }
     }
 
+    /// Rejects a name or id that is not usable as a single path component.
+    ///
+    /// Both are joined into the install dir and interpolated into resource
+    /// paths, so a caller-supplied override containing `/` or `..` would escape
+    /// it. The derived defaults are always dot-separated and unaffected.
+    fn validate_names(pkg_name: &str, pkg_id: &str) -> SoarResult<()> {
+        if !is_safe_component(pkg_name) {
+            return Err(SoarError::Custom(format!(
+                "Invalid package name '{}': must be a single path component",
+                pkg_name
+            )));
+        }
+        if !is_safe_component(pkg_id) {
+            return Err(SoarError::Custom(format!(
+                "Invalid package id '{}': must be a single path component",
+                pkg_id
+            )));
+        }
+        Ok(())
+    }
+
     /// Parse a GHCR reference and extract package metadata.
     pub fn from_ghcr(
         reference: &str,
@@ -128,6 +150,8 @@ impl UrlPackage {
             .unwrap_or_else(|| package.replace('/', "."));
 
         let pkg_type = pkg_type_override.map(|s| s.to_lowercase());
+
+        Self::validate_names(&pkg_name, &pkg_id)?;
 
         Ok(Self {
             url: reference.to_string(),
@@ -206,6 +230,8 @@ impl UrlPackage {
                     pkg_name.clone()
                 }
             });
+
+        Self::validate_names(&pkg_name, &pkg_id)?;
 
         Ok(Self {
             url: url.to_string(),
@@ -562,6 +588,25 @@ mod tests {
         assert_eq!(pkg.version, "2.0.0");
         assert_eq!(pkg.pkg_id, "custom-id");
         assert!(pkg.is_ghcr);
+    }
+
+    #[test]
+    fn test_ghcr_rejects_traversal_overrides() {
+        let ghcr = "ghcr.io/org/repo:v1.0";
+
+        assert!(UrlPackage::from_ghcr(ghcr, Some("../../evil"), None, None, None).is_err());
+        assert!(UrlPackage::from_ghcr(ghcr, None, None, None, Some("../../evil")).is_err());
+        assert!(UrlPackage::from_ghcr(ghcr, None, None, None, Some("/abs/evil")).is_err());
+        assert!(UrlPackage::from_ghcr(ghcr, Some(".."), None, None, None).is_err());
+    }
+
+    #[test]
+    fn test_url_rejects_traversal_overrides() {
+        let url = "https://github.com/user/repo/releases/download/v1.0/app";
+
+        assert!(UrlPackage::from_url(url, Some("../../evil"), None, None, None).is_err());
+        assert!(UrlPackage::from_url(url, None, None, None, Some("../../evil")).is_err());
+        assert!(UrlPackage::from_url(url, None, None, None, Some("a/b")).is_err());
     }
 
     #[test]

--- a/crates/soar-db/src/repository/metadata.rs
+++ b/crates/soar-db/src/repository/metadata.rs
@@ -6,6 +6,7 @@ use diesel::{dsl::sql, prelude::*, sql_types::Text};
 use regex::Regex;
 use serde_json::json;
 use soar_registry::RemotePackage;
+use soar_utils::path::is_safe_component;
 use tracing::{debug, trace, warn};
 
 /// Regex for extracting name and contact from maintainer string format "Name (contact)".
@@ -524,6 +525,18 @@ impl MetadataRepository {
             version = package.version,
             "inserting remote package"
         );
+
+        // pkg_name and pkg_id are joined into the install dir and interpolated
+        // into resource paths, so a name with separators or '..' would escape it.
+        if !is_safe_component(&package.pkg_name) || !is_safe_component(&package.pkg_id) {
+            warn!(
+                pkg_id = package.pkg_id,
+                pkg_name = package.pkg_name,
+                "skipping package with unsafe path component in pkg_name/pkg_id"
+            );
+            return Ok(());
+        }
+
         let provides = package.provides.as_ref().map(|vec| {
             vec.iter()
                 .map(|p| PackageProvide::from_string(p))

--- a/crates/soar-operations/src/install.rs
+++ b/crates/soar-operations/src/install.rs
@@ -35,6 +35,7 @@ use soar_package::integrate_package;
 use soar_utils::{
     hash::{calculate_checksum, hash_string},
     lock::FileLock,
+    path::is_safe_component,
     pattern::apply_sig_variants,
 };
 use tokio::sync::Semaphore;
@@ -829,6 +830,15 @@ async fn install_single_package(
             let input = format!("{}:{}:{}", pkg.pkg_id, pkg.pkg_name, pkg.version);
             hash_string(&input)[..12].to_string()
         });
+
+    // pkg_name/pkg_id are joined into install_dir and interpolated into resource
+    // paths downstream, so they must not be able to escape the packages dir.
+    if !is_safe_component(&pkg.pkg_name) || !is_safe_component(&pkg.pkg_id) {
+        return Err(SoarError::Custom(format!(
+            "Refusing to install {}#{}: package name or id is not a valid path component",
+            pkg.pkg_name, pkg.pkg_id
+        )));
+    }
 
     let install_dir = config
         .get_packages_path(target.profile.clone())?


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added path-safety validation for package names and IDs.
  * Rejected package paths containing traversal sequences, absolute paths, or nested components.
  * Prevented unsafe packages from being imported or installed.
  * Added coverage for invalid package path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->