### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 
+## [0.13.0](https://github.com/pkgforge/soar/compare/v0.12.7...v0.13.0) - 2026-08-02
+
+### ⛰️  Features
+
+- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
+- *(package)* Add onelf support - ([0059732](https://github.com/pkgforge/soar/commit/0059732adb754a15505f6345c86a3cf693ed8d23))
+- *(remove)* Accept the URL a package was installed from - ([cb95df8](https://github.com/pkgforge/soar/commit/cb95df8a081d4d363ec1c9fde3b6e207dc3ab218))
+- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
+- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
+- *(update)* Accept the URL a package was installed from - ([5434005](https://github.com/pkgforge/soar/commit/5434005c15c3a49ee91a37456adf5dc064a6eef3))
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 🐛 Bug Fixes
+
+- *(remove)* Drop '#all', which duplicated a bare name - ([28fc0fc](https://github.com/pkgforge/soar/commit/28fc0fc2c26af6401275856224d9691044050733))
+- *(update)* Keep matching when a repo stops publishing families - ([a04c9a7](https://github.com/pkgforge/soar/commit/a04c9a75cf5807dd89aa5bbcaa3397f8aee97f14))
+- *(update)* Say why a source check failed - ([64e115e](https://github.com/pkgforge/soar/commit/64e115e70895839c57b94b2ee3d9d58ef7923ed8))
+- *(update)* Trust the checksum, not the version label - ([e05092d](https://github.com/pkgforge/soar/commit/e05092db24e9ff4a60c65a2e368d5f92fc8e9e0d))
+- *(url)* Take the version from the release tag, not the arch - ([21de292](https://github.com/pkgforge/soar/commit/21de292d87eccb96fda730cd0937629cf5600a98))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.12.7](https://github.com/pkgforge/soar/compare/v0.12.6...v0.12.7) - 2026-07-16
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,7 +2215,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "soar-cli"
-version = "0.12.7"
+version = "0.13.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "soar-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "documented",
  "miette",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "soar-core"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "compak",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "soar-db"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "soar-dl"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "compak",
  "fast-glob",
@@ -2330,11 +2330,11 @@ dependencies = [
 
 [[package]]
 name = "soar-events"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "soar-operations"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "fast-glob",
  "minisign-verify",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "soar-package"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "image",
  "miette",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "soar-registry"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "miette",
  "minisign-verify",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "soar-utils"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,15 +60,15 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["indexmap"] }
 serial_test = "3.5.0"
 sha2 = "0.11.0"
-soar-config = { version = "0.11.0", path = "crates/soar-config" }
-soar-core = { version = "0.16.4", path = "crates/soar-core" }
-soar-db = { version = "0.5.5", path = "crates/soar-db" }
-soar-dl = { version = "0.10.2", path = "crates/soar-dl" }
-soar-events = { version = "0.1.0", path = "crates/soar-events" }
-soar-operations = { version = "0.3.2", path = "crates/soar-operations" }
-soar-package = { version = "0.4.2", path = "crates/soar-package" }
-soar-registry = { version = "0.5.1", path = "crates/soar-registry" }
-soar-utils = { version = "0.4.3", path = "crates/soar-utils" }
+soar-config = { version = "0.12.0", path = "crates/soar-config" }
+soar-core = { version = "0.17.0", path = "crates/soar-core" }
+soar-db = { version = "0.6.0", path = "crates/soar-db" }
+soar-dl = { version = "0.11.0", path = "crates/soar-dl" }
+soar-events = { version = "0.2.0", path = "crates/soar-events" }
+soar-operations = { version = "0.4.0", path = "crates/soar-operations" }
+soar-package = { version = "0.5.0", path = "crates/soar-package" }
+soar-registry = { version = "0.6.0", path = "crates/soar-registry" }
+soar-utils = { version = "0.5.0", path = "crates/soar-utils" }
 squishy = { version = "0.5.1", features = ["appimage", "dwarfs"] }
 tabled = { version = "0.21", default-features = false, features = ["ansi"] }
 terminal_size = "0.4"

--- a/crates/soar-cli/Cargo.toml
+++ b/crates/soar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-cli"
-version = "0.12.7"
+version = "0.13.0"
 description = "A modern package manager for Linux"
 default-run = "soar"
 license.workspace = true

--- a/crates/soar-config/CHANGELOG.md
+++ b/crates/soar-config/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+## [0.12.0](https://github.com/pkgforge/soar/compare/soar-config-v0.11.0...soar-config-v0.12.0) - 2026-08-02
+
+### ⛰️  Features
+
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.11.0](https://github.com/pkgforge/soar/compare/soar-config-v0.10.0...soar-config-v0.11.0) - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/crates/soar-config/Cargo.toml
+++ b/crates/soar-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-config"
-version = "0.11.0"
+version = "0.12.0"
 description = "Configuration management for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-core/CHANGELOG.md
+++ b/crates/soar-core/CHANGELOG.md
@@ -1,4 +1,23 @@
 
+## [0.17.0](https://github.com/pkgforge/soar/compare/soar-core-v0.16.4...soar-core-v0.17.0) - 2026-08-02
+
+### ⛰️  Features
+
+- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
+- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
+- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 🐛 Bug Fixes
+
+- *(remove)* Drop '#all', which duplicated a bare name - ([28fc0fc](https://github.com/pkgforge/soar/commit/28fc0fc2c26af6401275856224d9691044050733))
+- *(url)* Take the version from the release tag, not the arch - ([21de292](https://github.com/pkgforge/soar/commit/21de292d87eccb96fda730cd0937629cf5600a98))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.16.4](https://github.com/pkgforge/soar/compare/soar-core-v0.16.3...soar-core-v0.16.4) - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/crates/soar-core/Cargo.toml
+++ b/crates/soar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-core"
-version = "0.16.4"
+version = "0.17.0"
 description = "Core library for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-db/CHANGELOG.md
+++ b/crates/soar-db/CHANGELOG.md
@@ -1,4 +1,22 @@
 
+## [0.6.0](https://github.com/pkgforge/soar/compare/soar-db-v0.5.5...soar-db-v0.6.0) - 2026-08-02
+
+### ⛰️  Features
+
+- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
+- *(remove)* Accept the URL a package was installed from - ([cb95df8](https://github.com/pkgforge/soar/commit/cb95df8a081d4d363ec1c9fde3b6e207dc3ab218))
+- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 🐛 Bug Fixes
+
+- *(update)* Keep matching when a repo stops publishing families - ([a04c9a7](https://github.com/pkgforge/soar/commit/a04c9a75cf5807dd89aa5bbcaa3397f8aee97f14))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.5.5](https://github.com/pkgforge/soar/compare/soar-db-v0.5.4...soar-db-v0.5.5) - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/crates/soar-db/Cargo.toml
+++ b/crates/soar-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-db"
-version = "0.5.5"
+version = "0.6.0"
 description = "Database operations for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-dl/CHANGELOG.md
+++ b/crates/soar-dl/CHANGELOG.md
@@ -1,4 +1,19 @@
 
+## [0.11.0](https://github.com/pkgforge/soar/compare/soar-dl-v0.10.2...soar-dl-v0.11.0) - 2026-08-02
+
+### ⛰️  Features
+
+- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
+- *(update)* Accept the URL a package was installed from - ([5434005](https://github.com/pkgforge/soar/commit/5434005c15c3a49ee91a37456adf5dc064a6eef3))
+- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
+- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.10.2](https://github.com/pkgforge/soar/compare/soar-dl-v0.10.1...soar-dl-v0.10.2) - 2026-07-16
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-dl/Cargo.toml
+++ b/crates/soar-dl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-dl"
-version = "0.10.2"
+version = "0.11.0"
 description = "Downloader for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-events/CHANGELOG.md
+++ b/crates/soar-events/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+## [0.2.0](https://github.com/pkgforge/soar/compare/soar-events-v0.1.0...soar-events-v0.2.0) - 2026-08-02
+
+### ⛰️  Features
+
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.1.0](https://github.com/pkgforge/soar/compare/soar-events-v0.0.0...soar-events-v0.1.0) - 2026-02-24
 
 ### ⛰️  Features

--- a/crates/soar-events/Cargo.toml
+++ b/crates/soar-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-events"
-version = "0.1.0"
+version = "0.2.0"
 description = "Event system for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-operations/CHANGELOG.md
+++ b/crates/soar-operations/CHANGELOG.md
@@ -1,4 +1,25 @@
 
+## [0.4.0](https://github.com/pkgforge/soar/compare/soar-operations-v0.3.2...soar-operations-v0.4.0) - 2026-08-02
+
+### ⛰️  Features
+
+- *(remove)* Accept the URL a package was installed from - ([cb95df8](https://github.com/pkgforge/soar/commit/cb95df8a081d4d363ec1c9fde3b6e207dc3ab218))
+- *(update)* Accept the URL a package was installed from - ([5434005](https://github.com/pkgforge/soar/commit/5434005c15c3a49ee91a37456adf5dc064a6eef3))
+- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
+- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 🐛 Bug Fixes
+
+- *(remove)* Drop '#all', which duplicated a bare name - ([28fc0fc](https://github.com/pkgforge/soar/commit/28fc0fc2c26af6401275856224d9691044050733))
+- *(update)* Say why a source check failed - ([64e115e](https://github.com/pkgforge/soar/commit/64e115e70895839c57b94b2ee3d9d58ef7923ed8))
+- *(update)* Trust the checksum, not the version label - ([e05092d](https://github.com/pkgforge/soar/commit/e05092db24e9ff4a60c65a2e368d5f92fc8e9e0d))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.3.2](https://github.com/pkgforge/soar/compare/soar-operations-v0.3.1...soar-operations-v0.3.2) - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/crates/soar-operations/Cargo.toml
+++ b/crates/soar-operations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-operations"
-version = "0.3.2"
+version = "0.4.0"
 description = "Business logic for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-package/CHANGELOG.md
+++ b/crates/soar-package/CHANGELOG.md
@@ -1,4 +1,16 @@
 
+## [0.5.0](https://github.com/pkgforge/soar/compare/soar-package-v0.4.2...soar-package-v0.5.0) - 2026-08-02
+
+### ⛰️  Features
+
+- *(package)* Add onelf support - ([0059732](https://github.com/pkgforge/soar/commit/0059732adb754a15505f6345c86a3cf693ed8d23))
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.4.2](https://github.com/pkgforge/soar/compare/soar-package-v0.4.1...soar-package-v0.4.2) - 2026-07-16
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-package/Cargo.toml
+++ b/crates/soar-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-package"
-version = "0.4.2"
+version = "0.5.0"
 description = "Package format handling for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-registry/CHANGELOG.md
+++ b/crates/soar-registry/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+## [0.6.0](https://github.com/pkgforge/soar/compare/soar-registry-v0.5.1...soar-registry-v0.6.0) - 2026-08-02
+
+### ⛰️  Features
+
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.5.1](https://github.com/pkgforge/soar/compare/soar-registry-v0.5.0...soar-registry-v0.5.1) - 2026-07-16
 
 ### ⛰️  Features

--- a/crates/soar-registry/Cargo.toml
+++ b/crates/soar-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-registry"
-version = "0.5.1"
+version = "0.6.0"
 description = "Registry management for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-utils/CHANGELOG.md
+++ b/crates/soar-utils/CHANGELOG.md
@@ -1,4 +1,16 @@
 
+## [0.5.0](https://github.com/pkgforge/soar/compare/soar-utils-v0.4.3...soar-utils-v0.5.0) - 2026-08-02
+
+### ⛰️  Features
+
+- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
+- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))
+
+### 📚 Documentation
+
+- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
+- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
+
 ## [0.4.3](https://github.com/pkgforge/soar/compare/soar-utils-v0.4.2...soar-utils-v0.4.3) - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/crates/soar-utils/Cargo.toml
+++ b/crates/soar-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-utils"
-version = "0.4.3"
+version = "0.5.0"
 description = "Utilities for soar package manager"
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `soar-utils`: 0.4.3 -> 0.5.0 (✓ API compatible changes)
* `soar-config`: 0.11.0 -> 0.12.0 (⚠ API breaking changes)
* `soar-dl`: 0.10.2 -> 0.11.0 (⚠ API breaking changes)
* `soar-registry`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `soar-db`: 0.5.5 -> 0.6.0 (⚠ API breaking changes)
* `soar-events`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `soar-package`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)
* `soar-core`: 0.16.4 -> 0.17.0 (⚠ API breaking changes)
* `soar-operations`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)
* `soar-cli`: 0.12.7 -> 0.13.0

### ⚠ `soar-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ResolvedPackage.family in /tmp/.tmplqIprj/soar/crates/soar-config/src/packages.rs:325
  field Config.completions in /tmp/.tmplqIprj/soar/crates/soar-config/src/config.rs:85
  field PackageOptions.family in /tmp/.tmplqIprj/soar/crates/soar-config/src/packages.rs:198
```

### ⚠ `soar-dl` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant DownloadError:Zsync in /tmp/.tmplqIprj/soar/crates/soar-dl/src/error.rs:80
```

### ⚠ `soar-registry` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RemotePackage.size in /tmp/.tmplqIprj/soar/crates/soar-registry/src/package.rs:159
  field RemotePackage.extra in /tmp/.tmplqIprj/soar/crates/soar-registry/src/package.rs:243
  field RemotePackage.files in /tmp/.tmplqIprj/soar/crates/soar-registry/src/package.rs:247
  field RemotePackage.size in /tmp/.tmplqIprj/soar/crates/soar-registry/src/package.rs:159
  field RemotePackage.extra in /tmp/.tmplqIprj/soar/crates/soar-registry/src/package.rs:243
  field RemotePackage.files in /tmp/.tmplqIprj/soar/crates/soar-registry/src/package.rs:247

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant RegistryError:UnsupportedFormat in /tmp/.tmplqIprj/soar/crates/soar-registry/src/error.rs:20
  variant RegistryError:UnsupportedFormat in /tmp/.tmplqIprj/soar/crates/soar-registry/src/error.rs:20

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field pkg_webpage of struct RemotePackage, previously in file /tmp/.tmpspuhIP/soar-registry/src/package.rs:143
  field tags of struct RemotePackage, previously in file /tmp/.tmpspuhIP/soar-registry/src/package.rs:183
  field pkg_webpage of struct RemotePackage, previously in file /tmp/.tmpspuhIP/soar-registry/src/package.rs:143
  field tags of struct RemotePackage, previously in file /tmp/.tmpspuhIP/soar-registry/src/package.rs:183
```

### ⚠ `soar-db` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Package.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:12
  field Package.download_url in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:27
  field Package.update_info in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:29
  field Package.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:12
  field Package.download_url in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:27
  field Package.update_info in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:29
  field NewPackage.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:100
  field NewPackage.download_url in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:114
  field NewPackage.update_info in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:115
  field NewPackage.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:100
  field NewPackage.download_url in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:114
  field NewPackage.update_info in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/core.rs:115
  field PackageListing.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/metadata.rs:142
  field NewPackage.extra in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/metadata.rs:230
  field NewPackage.files in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/metadata.rs:231
  field Package.extra in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/metadata.rs:48
  field Package.files in /tmp/.tmplqIprj/soar/crates/soar-db/src/models/metadata.rs:50
  field InstalledPackageWithPortable.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:65
  field InstalledPackageWithPortable.download_url in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:84
  field InstalledPackageWithPortable.update_info in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:85

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  CoreRepository::unlink_others_by_checksum, previously in file /tmp/.tmpspuhIP/soar-db/src/repository/core.rs:659
  CoreRepository::link_by_checksum, previously in file /tmp/.tmpspuhIP/soar-db/src/repository/core.rs:687

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  soar_db::repository::metadata::MetadataRepository::find_filtered takes 6 parameters in /tmp/.tmpspuhIP/soar-db/src/repository/metadata.rs:393, but now takes 7 parameters in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/metadata.rs:435
  soar_db::repository::metadata::MetadataRepository::find_newer_version takes 4 parameters in /tmp/.tmpspuhIP/soar-db/src/repository/metadata.rs:432, but now takes 5 parameters in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/metadata.rs:480
  soar_db::repository::core::CoreRepository::find_exact takes 5 parameters in /tmp/.tmpspuhIP/soar-db/src/repository/core.rs:172, but now takes 6 parameters in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:211
  soar_db::repository::core::CoreRepository::find_alternates takes 4 parameters in /tmp/.tmpspuhIP/soar-db/src/repository/core.rs:300, but now takes 5 parameters in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:359
  soar_db::repository::core::CoreRepository::unlink_others takes 4 parameters in /tmp/.tmpspuhIP/soar-db/src/repository/core.rs:422, but now takes 6 parameters in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:510
  soar_db::repository::core::CoreRepository::get_old_package_paths takes 5 parameters in /tmp/.tmpspuhIP/soar-db/src/repository/core.rs:579, but now takes 6 parameters in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:713
  soar_db::repository::core::CoreRepository::delete_old_packages takes 5 parameters in /tmp/.tmpspuhIP/soar-db/src/repository/core.rs:620, but now takes 6 parameters in /tmp/.tmplqIprj/soar/crates/soar-db/src/repository/core.rs:757

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct soar_db::schema::metadata::packages::dsl::pkg_webpage, previously in file /tmp/.tmpspuhIP/soar-db/src/schema/metadata.rs:17
  struct soar_db::schema::metadata::packages::columns::pkg_webpage, previously in file /tmp/.tmpspuhIP/soar-db/src/schema/metadata.rs:17
  struct soar_db::schema::metadata::packages::pkg_webpage, previously in file /tmp/.tmpspuhIP/soar-db/src/schema/metadata.rs:17
  struct soar_db::schema::metadata::packages::dsl::tags, previously in file /tmp/.tmpspuhIP/soar-db/src/schema/metadata.rs:17
  struct soar_db::schema::metadata::packages::columns::tags, previously in file /tmp/.tmpspuhIP/soar-db/src/schema/metadata.rs:17
  struct soar_db::schema::metadata::packages::tags, previously in file /tmp/.tmpspuhIP/soar-db/src/schema/metadata.rs:17

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field pkg_webpage of struct NewPackage, previously in file /tmp/.tmpspuhIP/soar-db/src/models/metadata.rs:193
  field tags of struct NewPackage, previously in file /tmp/.tmpspuhIP/soar-db/src/models/metadata.rs:211
  field pkg_webpage of struct Package, previously in file /tmp/.tmpspuhIP/soar-db/src/models/metadata.rs:13
  field tags of struct Package, previously in file /tmp/.tmpspuhIP/soar-db/src/models/metadata.rs:31
```

### ⚠ `soar-events` breaking changes

```text
--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field pkg_id of variant SoarEvent::DownloadStarting, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:10
  field pkg_id of variant SoarEvent::DownloadResuming, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:17
  field pkg_id of variant SoarEvent::DownloadProgress, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:25
  field pkg_id of variant SoarEvent::DownloadComplete, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:33
  field pkg_id of variant SoarEvent::DownloadRetry, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:40
  field pkg_id of variant SoarEvent::DownloadAborted, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:46
  field pkg_id of variant SoarEvent::DownloadRecovered, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:52
  field pkg_id of variant SoarEvent::Verifying, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:58
  field pkg_id of variant SoarEvent::Installing, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:65
  field pkg_id of variant SoarEvent::Removing, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:72
  field pkg_id of variant SoarEvent::UpdateCheck, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:78
  field pkg_id of variant SoarEvent::UpdateCleanup, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:85
  field pkg_id of variant SoarEvent::Hook, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:93
  field pkg_id of variant SoarEvent::Running, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:101
  field pkg_id of variant SoarEvent::Building, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:108
  field pkg_id of variant SoarEvent::OperationComplete, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:115
  field pkg_id of variant SoarEvent::OperationFailed, previously in file /tmp/.tmpspuhIP/soar-events/src/event.rs:121
```

### ⚠ `soar-package` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant PackageFormat::ELF 4 -> 5 in /tmp/.tmplqIprj/soar/crates/soar-package/src/formats/mod.rs:54
  variant PackageFormat::Unknown 5 -> 6 in /tmp/.tmplqIprj/soar/crates/soar-package/src/formats/mod.rs:56
  variant PackageFormat::ELF 4 -> 5 in /tmp/.tmplqIprj/soar/crates/soar-package/src/formats/mod.rs:54
  variant PackageFormat::Unknown 5 -> 6 in /tmp/.tmplqIprj/soar/crates/soar-package/src/formats/mod.rs:56

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant PackageFormat:Onelf in /tmp/.tmplqIprj/soar/crates/soar-package/src/formats/mod.rs:52
  variant PackageFormat:Onelf in /tmp/.tmplqIprj/soar/crates/soar-package/src/formats/mod.rs:52

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method soar_package::traits::PackageExt::pkg_family in file /tmp/.tmplqIprj/soar/crates/soar-package/src/traits.rs:16
  trait method soar_package::PackageExt::pkg_family in file /tmp/.tmplqIprj/soar/crates/soar-package/src/traits.rs:16
```

### ⚠ `soar-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field InstalledPackage.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-core/src/database/models.rs:147
  field InstalledPackage.download_url in /tmp/.tmplqIprj/soar/crates/soar-core/src/database/models.rs:167
  field InstalledPackage.update_info in /tmp/.tmplqIprj/soar/crates/soar-core/src/database/models.rs:169
  field Package.extra in /tmp/.tmplqIprj/soar/crates/soar-core/src/database/models.rs:71
  field Package.files in /tmp/.tmplqIprj/soar/crates/soar-core/src/database/models.rs:73
  field LocalPackage.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-core/src/package/local.rs:33
  field InstallTarget.zsync in /tmp/.tmplqIprj/soar/crates/soar-core/src/package/install.rs:490
  field PackageQuery.family in /tmp/.tmplqIprj/soar/crates/soar-core/src/package/query.rs:15
  field UrlPackage.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-core/src/package/url.rs:23

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field pkg_webpage of struct Package, previously in file /tmp/.tmpspuhIP/soar-core/src/database/models.rs:33
  field tags of struct Package, previously in file /tmp/.tmpspuhIP/soar-core/src/database/models.rs:49
```

### ⚠ `soar-operations` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SearchEntry.other_versions in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:136
  field SearchEntry.other_versions in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:136
  field PackageListEntry.other_versions in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:149
  field PackageListEntry.other_versions in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:149
  field InstalledInfo.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:60
  field InstalledInfo.shared in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:67
  field InstalledInfo.pkg_family in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:60
  field InstalledInfo.shared in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:67
  field HealthReport.man_path in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:172
  field HealthReport.man_path_configured in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:173
  field HealthReport.man_path in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:172
  field HealthReport.man_path_configured in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:173

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field pkg_id of variant ResolveResult::AlreadyInstalled, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:38
  field pkg_id of variant ResolveResult::AlreadyInstalled, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:38

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant PrepareRunResult::Ready in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:222
  variant PrepareRunResult::Ready in /tmp/.tmplqIprj/soar/crates/soar-operations/src/types.rs:222

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  soar_operations::progress::create_progress_bridge now takes 3 parameters instead of 4, in /tmp/.tmplqIprj/soar/crates/soar-operations/src/progress.rs:13
  soar_operations::utils::mangle_package_symlinks now takes 9 parameters instead of 8, in /tmp/.tmplqIprj/soar/crates/soar-operations/src/utils.rs:171

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field pkg_id of struct BrokenPackage, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:171
  field pkg_id of struct BrokenPackage, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:171
  field pkg_id of struct UpdateInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:105
  field pkg_id of struct UpdateInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:105
  field pkg_id of struct FailedInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:73
  field pkg_id of struct FailedInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:73
  field pkg_id of struct InstalledInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:61
  field pkg_id of struct InstalledInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:61
  field pkg_id of struct RemovedInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:96
  field pkg_id of struct RemovedInfo, previously in file /tmp/.tmpspuhIP/soar-operations/src/types.rs:96
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `soar-utils`

<blockquote>

## [0.5.0](https://github.com/pkgforge/soar/compare/soar-utils-v0.4.3...soar-utils-v0.5.0) - 2026-08-02

### ⛰️  Features

- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-config`

<blockquote>

## [0.12.0](https://github.com/pkgforge/soar/compare/soar-config-v0.11.0...soar-config-v0.12.0) - 2026-08-02

### ⛰️  Features

- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-dl`

<blockquote>

## [0.11.0](https://github.com/pkgforge/soar/compare/soar-dl-v0.10.2...soar-dl-v0.11.0) - 2026-08-02

### ⛰️  Features

- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
- *(update)* Accept the URL a package was installed from - ([5434005](https://github.com/pkgforge/soar/commit/5434005c15c3a49ee91a37456adf5dc064a6eef3))
- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-registry`

<blockquote>

## [0.6.0](https://github.com/pkgforge/soar/compare/soar-registry-v0.5.1...soar-registry-v0.6.0) - 2026-08-02

### ⛰️  Features

- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-db`

<blockquote>

## [0.6.0](https://github.com/pkgforge/soar/compare/soar-db-v0.5.5...soar-db-v0.6.0) - 2026-08-02

### ⛰️  Features

- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
- *(remove)* Accept the URL a package was installed from - ([cb95df8](https://github.com/pkgforge/soar/commit/cb95df8a081d4d363ec1c9fde3b6e207dc3ab218))
- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 🐛 Bug Fixes

- *(update)* Keep matching when a repo stops publishing families - ([a04c9a7](https://github.com/pkgforge/soar/commit/a04c9a75cf5807dd89aa5bbcaa3397f8aee97f14))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-events`

<blockquote>

## [0.2.0](https://github.com/pkgforge/soar/compare/soar-events-v0.1.0...soar-events-v0.2.0) - 2026-08-02

### ⛰️  Features

- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-package`

<blockquote>

## [0.5.0](https://github.com/pkgforge/soar/compare/soar-package-v0.4.2...soar-package-v0.5.0) - 2026-08-02

### ⛰️  Features

- *(package)* Add onelf support - ([0059732](https://github.com/pkgforge/soar/commit/0059732adb754a15505f6345c86a3cf693ed8d23))
- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-core`

<blockquote>

## [0.17.0](https://github.com/pkgforge/soar/compare/soar-core-v0.16.4...soar-core-v0.17.0) - 2026-08-02

### ⛰️  Features

- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 🐛 Bug Fixes

- *(remove)* Drop '#all', which duplicated a bare name - ([28fc0fc](https://github.com/pkgforge/soar/commit/28fc0fc2c26af6401275856224d9691044050733))
- *(url)* Take the version from the release tag, not the arch - ([21de292](https://github.com/pkgforge/soar/commit/21de292d87eccb96fda730cd0937629cf5600a98))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-operations`

<blockquote>

## [0.4.0](https://github.com/pkgforge/soar/compare/soar-operations-v0.3.2...soar-operations-v0.4.0) - 2026-08-02

### ⛰️  Features

- *(remove)* Accept the URL a package was installed from - ([cb95df8](https://github.com/pkgforge/soar/commit/cb95df8a081d4d363ec1c9fde3b6e207dc3ab218))
- *(update)* Accept the URL a package was installed from - ([5434005](https://github.com/pkgforge/soar/commit/5434005c15c3a49ee91a37456adf5dc064a6eef3))
- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 🐛 Bug Fixes

- *(remove)* Drop '#all', which duplicated a bare name - ([28fc0fc](https://github.com/pkgforge/soar/commit/28fc0fc2c26af6401275856224d9691044050733))
- *(update)* Say why a source check failed - ([64e115e](https://github.com/pkgforge/soar/commit/64e115e70895839c57b94b2ee3d9d58ef7923ed8))
- *(update)* Trust the checksum, not the version label - ([e05092d](https://github.com/pkgforge/soar/commit/e05092db24e9ff4a60c65a2e368d5f92fc8e9e0d))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>

## `soar-cli`

<blockquote>

## [0.13.0](https://github.com/pkgforge/soar/compare/v0.12.7...v0.13.0) - 2026-08-02

### ⛰️  Features

- *(install)* Record where a URL install came from - ([d6c83ad](https://github.com/pkgforge/soar/commit/d6c83adf7ee42783d1f415b3c1c2a601f6b6d9c1))
- *(package)* Add onelf support - ([0059732](https://github.com/pkgforge/soar/commit/0059732adb754a15505f6345c86a3cf693ed8d23))
- *(remove)* Accept the URL a package was installed from - ([cb95df8](https://github.com/pkgforge/soar/commit/cb95df8a081d4d363ec1c9fde3b6e207dc3ab218))
- *(update)* Follow a release source when no feed is declared - ([178b87a](https://github.com/pkgforge/soar/commit/178b87a48b34dfab3af4f986569c6fb3ec8d1244))
- *(update)* Update URL-installed AppImages over zsync - ([509df1f](https://github.com/pkgforge/soar/commit/509df1fb1ca0d0e50d12f6eee1652d368acb71ba))
- *(update)* Accept the URL a package was installed from - ([5434005](https://github.com/pkgforge/soar/commit/5434005c15c3a49ee91a37456adf5dc064a6eef3))
- [**breaking**] Consume the declarative index, drop the pkg_id requirement ([#186](https://github.com/pkgforge/soar/pull/186)) - ([3a35ad7](https://github.com/pkgforge/soar/commit/3a35ad7774e7ac3d8c055e4257cb3e9dff5be2fe))

### 🐛 Bug Fixes

- *(remove)* Drop '#all', which duplicated a bare name - ([28fc0fc](https://github.com/pkgforge/soar/commit/28fc0fc2c26af6401275856224d9691044050733))
- *(update)* Keep matching when a repo stops publishing families - ([a04c9a7](https://github.com/pkgforge/soar/commit/a04c9a75cf5807dd89aa5bbcaa3397f8aee97f14))
- *(update)* Say why a source check failed - ([64e115e](https://github.com/pkgforge/soar/commit/64e115e70895839c57b94b2ee3d9d58ef7923ed8))
- *(update)* Trust the checksum, not the version label - ([e05092d](https://github.com/pkgforge/soar/commit/e05092db24e9ff4a60c65a2e368d5f92fc8e9e0d))
- *(url)* Take the version from the release tag, not the arch - ([21de292](https://github.com/pkgforge/soar/commit/21de292d87eccb96fda730cd0937629cf5600a98))

### 📚 Documentation

- Cover forge tokens and rate limits - ([ccdd34a](https://github.com/pkgforge/soar/commit/ccdd34ad3f09a90994b85e917a45885fd1c3e413))
- Refresh the readme and contributing guidelines - ([5ecd397](https://github.com/pkgforge/soar/commit/5ecd397e853d7d601677766ccf73dc68c063f015))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).