### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 
+## [0.13.2](https://github.com/pkgforge/soar/compare/v0.13.1...v0.13.2) - 2026-08-15
+
+### ⛰️  Features
+
+- *(cli)* Install packages from soar:// links ([#197](https://github.com/pkgforge/soar/pull/197)) - ([e447e7c](https://github.com/pkgforge/soar/commit/e447e7cf9ea96a2c06300277b0856c91d557b279))
+- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 🐛 Bug Fixes
+
+- *(desktop)* Leave no space after a command with no arguments - ([87ae748](https://github.com/pkgforge/soar/commit/87ae74891ccc620dfdf4b27a63d1caf741df3ec8))
+- *(plugin-manifest)* Let update name the package it means - ([fe0397d](https://github.com/pkgforge/soar/commit/fe0397d9eaee30c9ae91b5288ee81c20d705b328))
+- *(registry)* Read the date the metadata actually publishes ([#196](https://github.com/pkgforge/soar/pull/196)) - ([2772841](https://github.com/pkgforge/soar/commit/277284138cfd9e344d72048cca5be6cac7147ae8))
+- *(search)* Match a package whose family the metadata has dropped ([#201](https://github.com/pkgforge/soar/pull/201)) - ([e6057fb](https://github.com/pkgforge/soar/commit/e6057fb7763e4b679beb2e5d8d38c89f4e3218bc))
+- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.13.1](https://github.com/pkgforge/soar/compare/v0.13.0...v0.13.1) - 2026-08-05
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,7 +2215,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "soar-cli"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "soar-config"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "documented",
  "miette",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "soar-core"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "chrono",
  "compak",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "soar-db"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "soar-dl"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "compak",
  "fast-glob",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "soar-events"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "soar-operations"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "fast-glob",
  "minisign-verify",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "soar-package"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "image",
  "miette",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "soar-registry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "miette",
  "minisign-verify",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "soar-utils"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "blake3",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,15 +60,15 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["indexmap"] }
 serial_test = "3.5.0"
 sha2 = "0.11.0"
-soar-config = { version = "0.12.0", path = "crates/soar-config" }
-soar-core = { version = "0.17.1", path = "crates/soar-core" }
-soar-db = { version = "0.6.1", path = "crates/soar-db" }
-soar-dl = { version = "0.12.0", path = "crates/soar-dl" }
-soar-events = { version = "0.2.0", path = "crates/soar-events" }
-soar-operations = { version = "0.4.1", path = "crates/soar-operations" }
-soar-package = { version = "0.5.0", path = "crates/soar-package" }
-soar-registry = { version = "0.6.1", path = "crates/soar-registry" }
-soar-utils = { version = "0.5.0", path = "crates/soar-utils" }
+soar-config = { version = "0.12.1", path = "crates/soar-config" }
+soar-core = { version = "0.17.2", path = "crates/soar-core" }
+soar-db = { version = "0.7.0", path = "crates/soar-db" }
+soar-dl = { version = "0.12.1", path = "crates/soar-dl" }
+soar-events = { version = "0.3.0", path = "crates/soar-events" }
+soar-operations = { version = "0.5.0", path = "crates/soar-operations" }
+soar-package = { version = "0.5.1", path = "crates/soar-package" }
+soar-registry = { version = "0.6.2", path = "crates/soar-registry" }
+soar-utils = { version = "0.5.1", path = "crates/soar-utils" }
 squishy = { version = "0.5.1", features = ["appimage", "dwarfs"] }
 tabled = { version = "0.21", default-features = false, features = ["ansi"] }
 terminal_size = "0.4"

--- a/crates/soar-cli/Cargo.toml
+++ b/crates/soar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-cli"
-version = "0.13.1"
+version = "0.13.2"
 description = "A modern package manager for Linux"
 default-run = "soar"
 license.workspace = true

--- a/crates/soar-config/CHANGELOG.md
+++ b/crates/soar-config/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.12.1](https://github.com/pkgforge/soar/compare/soar-config-v0.12.0...soar-config-v0.12.1) - 2026-08-15
+
+### ⛰️  Features
+
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.12.0](https://github.com/pkgforge/soar/compare/soar-config-v0.11.0...soar-config-v0.12.0) - 2026-08-02
 
 ### ⛰️  Features

--- a/crates/soar-config/Cargo.toml
+++ b/crates/soar-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-config"
-version = "0.12.0"
+version = "0.12.1"
 description = "Configuration management for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-core/CHANGELOG.md
+++ b/crates/soar-core/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.17.2](https://github.com/pkgforge/soar/compare/soar-core-v0.17.1...soar-core-v0.17.2) - 2026-08-15
+
+### ⛰️  Features
+
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.17.1](https://github.com/pkgforge/soar/compare/soar-core-v0.17.0...soar-core-v0.17.1) - 2026-08-05
 
 ### 🐛 Bug Fixes

--- a/crates/soar-core/Cargo.toml
+++ b/crates/soar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-core"
-version = "0.17.1"
+version = "0.17.2"
 description = "Core library for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-db/CHANGELOG.md
+++ b/crates/soar-db/CHANGELOG.md
@@ -1,4 +1,20 @@
 
+## [0.7.0](https://github.com/pkgforge/soar/compare/soar-db-v0.6.1...soar-db-v0.7.0) - 2026-08-15
+
+### ⛰️  Features
+
+- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 🐛 Bug Fixes
+
+- *(search)* Match a package whose family the metadata has dropped ([#201](https://github.com/pkgforge/soar/pull/201)) - ([e6057fb](https://github.com/pkgforge/soar/commit/e6057fb7763e4b679beb2e5d8d38c89f4e3218bc))
+- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.6.1](https://github.com/pkgforge/soar/compare/soar-db-v0.6.0...soar-db-v0.6.1) - 2026-08-05
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-db/Cargo.toml
+++ b/crates/soar-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-db"
-version = "0.6.1"
+version = "0.7.0"
 description = "Database operations for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-dl/CHANGELOG.md
+++ b/crates/soar-dl/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.12.1](https://github.com/pkgforge/soar/compare/soar-dl-v0.12.0...soar-dl-v0.12.1) - 2026-08-15
+
+### ⛰️  Features
+
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.12.0](https://github.com/pkgforge/soar/compare/soar-dl-v0.11.0...soar-dl-v0.12.0) - 2026-08-05
 
 ### ⛰️  Features

--- a/crates/soar-dl/Cargo.toml
+++ b/crates/soar-dl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-dl"
-version = "0.12.0"
+version = "0.12.1"
 description = "Downloader for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-events/CHANGELOG.md
+++ b/crates/soar-events/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+## [0.3.0](https://github.com/pkgforge/soar/compare/soar-events-v0.2.0...soar-events-v0.3.0) - 2026-08-15
+
+### ⛰️  Features
+
+- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.2.0](https://github.com/pkgforge/soar/compare/soar-events-v0.1.0...soar-events-v0.2.0) - 2026-08-02
 
 ### ⛰️  Features

--- a/crates/soar-events/Cargo.toml
+++ b/crates/soar-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-events"
-version = "0.2.0"
+version = "0.3.0"
 description = "Event system for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-operations/CHANGELOG.md
+++ b/crates/soar-operations/CHANGELOG.md
@@ -1,4 +1,20 @@
 
+## [0.5.0](https://github.com/pkgforge/soar/compare/soar-operations-v0.4.1...soar-operations-v0.5.0) - 2026-08-15
+
+### ⛰️  Features
+
+- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 🐛 Bug Fixes
+
+- *(search)* Match a package whose family the metadata has dropped ([#201](https://github.com/pkgforge/soar/pull/201)) - ([e6057fb](https://github.com/pkgforge/soar/commit/e6057fb7763e4b679beb2e5d8d38c89f4e3218bc))
+- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.4.1](https://github.com/pkgforge/soar/compare/soar-operations-v0.4.0...soar-operations-v0.4.1) - 2026-08-05
 
 ### 🐛 Bug Fixes

--- a/crates/soar-operations/Cargo.toml
+++ b/crates/soar-operations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-operations"
-version = "0.4.1"
+version = "0.5.0"
 description = "Business logic for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-package/CHANGELOG.md
+++ b/crates/soar-package/CHANGELOG.md
@@ -1,4 +1,18 @@
 
+## [0.5.1](https://github.com/pkgforge/soar/compare/soar-package-v0.5.0...soar-package-v0.5.1) - 2026-08-15
+
+### ⛰️  Features
+
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 🐛 Bug Fixes
+
+- *(desktop)* Leave no space after a command with no arguments - ([87ae748](https://github.com/pkgforge/soar/commit/87ae74891ccc620dfdf4b27a63d1caf741df3ec8))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.5.0](https://github.com/pkgforge/soar/compare/soar-package-v0.4.2...soar-package-v0.5.0) - 2026-08-02
 
 ### ⛰️  Features

--- a/crates/soar-package/Cargo.toml
+++ b/crates/soar-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-package"
-version = "0.5.0"
+version = "0.5.1"
 description = "Package format handling for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-registry/CHANGELOG.md
+++ b/crates/soar-registry/CHANGELOG.md
@@ -1,4 +1,19 @@
 
+## [0.6.2](https://github.com/pkgforge/soar/compare/soar-registry-v0.6.1...soar-registry-v0.6.2) - 2026-08-15
+
+### ⛰️  Features
+
+- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 🐛 Bug Fixes
+
+- *(registry)* Read the date the metadata actually publishes ([#196](https://github.com/pkgforge/soar/pull/196)) - ([2772841](https://github.com/pkgforge/soar/commit/277284138cfd9e344d72048cca5be6cac7147ae8))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.6.1](https://github.com/pkgforge/soar/compare/soar-registry-v0.6.0...soar-registry-v0.6.1) - 2026-08-05
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-registry/Cargo.toml
+++ b/crates/soar-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-registry"
-version = "0.6.1"
+version = "0.6.2"
 description = "Registry management for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-utils/CHANGELOG.md
+++ b/crates/soar-utils/CHANGELOG.md
@@ -1,4 +1,18 @@
 
+## [0.5.1](https://github.com/pkgforge/soar/compare/soar-utils-v0.5.0...soar-utils-v0.5.1) - 2026-08-15
+
+### ⛰️  Features
+
+- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))
+
+### 🐛 Bug Fixes
+
+- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))
+
+### 📚 Documentation
+
+- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
+
 ## [0.5.0](https://github.com/pkgforge/soar/compare/soar-utils-v0.4.3...soar-utils-v0.5.0) - 2026-08-02
 
 ### ⛰️  Features

--- a/crates/soar-utils/Cargo.toml
+++ b/crates/soar-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-utils"
-version = "0.5.0"
+version = "0.5.1"
 description = "Utilities for soar package manager"
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `soar-utils`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `soar-config`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `soar-dl`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `soar-registry`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `soar-db`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `soar-events`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `soar-package`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `soar-core`: 0.17.1 -> 0.17.2 (✓ API compatible changes)
* `soar-operations`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `soar-cli`: 0.13.1 -> 0.13.2

### ⚠ `soar-db` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  soar_db::repository::metadata::MetadataRepository::find_newer_version takes 5 parameters in /tmp/.tmpEffDmw/soar-db/src/repository/metadata.rs:480, but now takes 6 parameters in /tmp/.tmpiZHQuf/soar/crates/soar-db/src/repository/metadata.rs:528
```

### ⚠ `soar-events` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant SoarEvent::Log 19 -> 20 in /tmp/.tmpiZHQuf/soar/crates/soar-events/src/event.rs:124

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant SoarEvent:ApplyComplete in /tmp/.tmpiZHQuf/soar/crates/soar-events/src/event.rs:117
```

### ⚠ `soar-operations` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  soar_operations::utils::is_installed now takes 5 parameters instead of 4, in /tmp/.tmpiZHQuf/soar/crates/soar-operations/src/utils.rs:527
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `soar-utils`

<blockquote>

## [0.5.1](https://github.com/pkgforge/soar/compare/soar-utils-v0.5.0...soar-utils-v0.5.1) - 2026-08-15

### ⛰️  Features

- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 🐛 Bug Fixes

- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-config`

<blockquote>

## [0.12.1](https://github.com/pkgforge/soar/compare/soar-config-v0.12.0...soar-config-v0.12.1) - 2026-08-15

### ⛰️  Features

- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-dl`

<blockquote>

## [0.12.1](https://github.com/pkgforge/soar/compare/soar-dl-v0.12.0...soar-dl-v0.12.1) - 2026-08-15

### ⛰️  Features

- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-registry`

<blockquote>

## [0.6.2](https://github.com/pkgforge/soar/compare/soar-registry-v0.6.1...soar-registry-v0.6.2) - 2026-08-15

### ⛰️  Features

- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 🐛 Bug Fixes

- *(registry)* Read the date the metadata actually publishes ([#196](https://github.com/pkgforge/soar/pull/196)) - ([2772841](https://github.com/pkgforge/soar/commit/277284138cfd9e344d72048cca5be6cac7147ae8))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-db`

<blockquote>

## [0.7.0](https://github.com/pkgforge/soar/compare/soar-db-v0.6.1...soar-db-v0.7.0) - 2026-08-15

### ⛰️  Features

- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 🐛 Bug Fixes

- *(search)* Match a package whose family the metadata has dropped ([#201](https://github.com/pkgforge/soar/pull/201)) - ([e6057fb](https://github.com/pkgforge/soar/commit/e6057fb7763e4b679beb2e5d8d38c89f4e3218bc))
- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-events`

<blockquote>

## [0.3.0](https://github.com/pkgforge/soar/compare/soar-events-v0.2.0...soar-events-v0.3.0) - 2026-08-15

### ⛰️  Features

- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-package`

<blockquote>

## [0.5.1](https://github.com/pkgforge/soar/compare/soar-package-v0.5.0...soar-package-v0.5.1) - 2026-08-15

### ⛰️  Features

- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 🐛 Bug Fixes

- *(desktop)* Leave no space after a command with no arguments - ([87ae748](https://github.com/pkgforge/soar/commit/87ae74891ccc620dfdf4b27a63d1caf741df3ec8))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-core`

<blockquote>

## [0.17.2](https://github.com/pkgforge/soar/compare/soar-core-v0.17.1...soar-core-v0.17.2) - 2026-08-15

### ⛰️  Features

- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-operations`

<blockquote>

## [0.5.0](https://github.com/pkgforge/soar/compare/soar-operations-v0.4.1...soar-operations-v0.5.0) - 2026-08-15

### ⛰️  Features

- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 🐛 Bug Fixes

- *(search)* Match a package whose family the metadata has dropped ([#201](https://github.com/pkgforge/soar/pull/201)) - ([e6057fb](https://github.com/pkgforge/soar/commit/e6057fb7763e4b679beb2e5d8d38c89f4e3218bc))
- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>

## `soar-cli`

<blockquote>

## [0.13.2](https://github.com/pkgforge/soar/compare/v0.13.1...v0.13.2) - 2026-08-15

### ⛰️  Features

- *(cli)* Install packages from soar:// links ([#197](https://github.com/pkgforge/soar/pull/197)) - ([e447e7c](https://github.com/pkgforge/soar/commit/e447e7cf9ea96a2c06300277b0856c91d557b279))
- *(cli)* Expose soar to frontends with JSON output and a plugin manifest ([#194](https://github.com/pkgforge/soar/pull/194)) - ([6846b89](https://github.com/pkgforge/soar/commit/6846b893dedb373ed6d4254b13548b43be407fe5))
- Serve soarpkgs on riscv64 and refresh the readme ([#198](https://github.com/pkgforge/soar/pull/198)) - ([2224691](https://github.com/pkgforge/soar/commit/22246912045678b45969e69b1ee23da6af43fd26))

### 🐛 Bug Fixes

- *(desktop)* Leave no space after a command with no arguments - ([87ae748](https://github.com/pkgforge/soar/commit/87ae74891ccc620dfdf4b27a63d1caf741df3ec8))
- *(plugin-manifest)* Let update name the package it means - ([fe0397d](https://github.com/pkgforge/soar/commit/fe0397d9eaee30c9ae91b5288ee81c20d705b328))
- *(registry)* Read the date the metadata actually publishes ([#196](https://github.com/pkgforge/soar/pull/196)) - ([2772841](https://github.com/pkgforge/soar/commit/277284138cfd9e344d72048cca5be6cac7147ae8))
- *(search)* Match a package whose family the metadata has dropped ([#201](https://github.com/pkgforge/soar/pull/201)) - ([e6057fb](https://github.com/pkgforge/soar/commit/e6057fb7763e4b679beb2e5d8d38c89f4e3218bc))
- *(update)* Let the artifact decide where the version cannot - ([c656564](https://github.com/pkgforge/soar/commit/c656564f1d39548f3343acc0d049b1b01b370b00))

### 📚 Documentation

- Refresh README and CONTRIBUTING ([#199](https://github.com/pkgforge/soar/pull/199)) - ([6479cec](https://github.com/pkgforge/soar/commit/6479ceca42d8e1c452aaa11512457f10d98b6f5c))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).