### PR TITLE
fix(registry): read the date the metadata actually publishes

### DIFF
--- a/crates/soar-registry/src/package.rs
+++ b/crates/soar-registry/src/package.rs
@@ -192,7 +192,7 @@ pub struct RemotePackage {
     #[serde(default, deserialize_with = "empty_is_none")]
     pub build_id: Option<String>,
 
-    #[serde(default, deserialize_with = "empty_is_none")]
+    #[serde(default, deserialize_with = "empty_is_none", alias = "date")]
     pub build_date: Option<String>,
 
     #[serde(default, deserialize_with = "empty_is_none", alias = "build_gha")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package metadata compatibility by accepting `date` as an alternative serialized field for build dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->