### PR TITLE
fix(search): match a package whose family the metadata has dropped

### DIFF
--- a/crates/soar-db/src/repository/metadata.rs
+++ b/crates/soar-db/src/repository/metadata.rs
@@ -344,6 +344,23 @@ impl MetadataRepository {
         packages::table.count().get_result(conn)
     }
 
+    /// How many packages the repository offers under each name, counting a
+    /// name once per family it is published under.
+    ///
+    /// A name standing for a single package means the same package however
+    /// its family is recorded, which is what lets one installed under a
+    /// family since dropped go on being recognised.
+    pub fn count_names(conn: &mut SqliteConnection) -> QueryResult<Vec<(String, i64)>> {
+        trace!("counting what each package name stands for");
+        packages::table
+            .group_by(packages::pkg_name)
+            .select((
+                packages::pkg_name,
+                sql::<diesel::sql_types::BigInt>("COUNT(DISTINCT COALESCE(pkg_family, ''))"),
+            ))
+            .load(conn)
+    }
+
     /// Counts packages matching a search pattern using Diesel DSL.
     pub fn count_search(conn: &mut SqliteConnection, pattern: &str) -> QueryResult<i64> {
         let like_pattern = format!("%{}%", pattern.to_lowercase());

--- a/crates/soar-operations/src/list.rs
+++ b/crates/soar-operations/src/list.rs
@@ -13,7 +13,7 @@ use soar_utils::{fs::dir_size, version::compare_versions};
 use tracing::{debug, trace};
 
 use crate::{
-    utils::{is_installed, InstalledIndex, PackageKey},
+    utils::{is_installed, InstalledIndex, NameCounts, PackageKey},
     InstalledEntry, InstalledListResult, PackageListEntry, PackageListResult, SoarContext,
 };
 
@@ -120,6 +120,16 @@ pub async fn list_packages(
             acc
         });
 
+    let offered: NameCounts = metadata_mgr
+        .query_all(|_repo_name, conn| MetadataRepository::count_names(conn))?
+        .into_iter()
+        .flat_map(|(repo_name, rows)| {
+            rows.into_iter().map(move |(pkg_name, offered)| {
+                ((repo_name.clone(), pkg_name), offered.max(0) as usize)
+            })
+        })
+        .collect();
+
     let total = packages.len();
 
     let entries: Vec<PackageListEntry> = packages
@@ -127,6 +137,7 @@ pub async fn list_packages(
         .map(|entry| {
             let installed = is_installed(
                 &installed_pkgs,
+                &offered,
                 &entry.repo_name,
                 &entry.pkg.pkg_name,
                 entry.pkg.pkg_family.as_deref(),

--- a/crates/soar-operations/src/search.rs
+++ b/crates/soar-operations/src/search.rs
@@ -18,7 +18,7 @@ use soar_utils::version::compare_versions;
 use tracing::{debug, trace};
 
 use crate::{
-    utils::{is_installed, InstalledIndex, PackageKey},
+    utils::{is_installed, InstalledIndex, NameCounts, PackageKey},
     SearchEntry, SearchResult, SoarContext,
 };
 
@@ -122,6 +122,16 @@ pub async fn search_packages(
             acc
         });
 
+    let offered: NameCounts = metadata_mgr
+        .query_all(|_repo_name, conn| MetadataRepository::count_names(conn))?
+        .into_iter()
+        .flat_map(|(repo_name, rows)| {
+            rows.into_iter().map(move |(pkg_name, offered)| {
+                ((repo_name.clone(), pkg_name), offered.max(0) as usize)
+            })
+        })
+        .collect();
+
     let total_count = packages.len();
 
     let entries: Vec<SearchEntry> = packages
@@ -130,6 +140,7 @@ pub async fn search_packages(
         .map(|package| {
             let installed = is_installed(
                 &installed_pkgs,
+                &offered,
                 &package.repo_name,
                 &package.pkg_name,
                 package.pkg_family.as_deref(),

--- a/crates/soar-operations/src/utils.rs
+++ b/crates/soar-operations/src/utils.rs
@@ -521,17 +521,38 @@ pub type PackageKey = (String, String, Option<String>, Option<String>);
 /// installed under, so a package sharing a name is not mistaken for it.
 pub type InstalledIndex = HashMap<(String, String), Vec<(Option<String>, bool)>>;
 
+/// How many packages a repository offers under each name.
+pub type NameCounts = HashMap<(String, String), usize>;
+
 pub fn is_installed(
     map: &InstalledIndex,
+    offered: &NameCounts,
     repo_name: &str,
     pkg_name: &str,
     pkg_family: Option<&str>,
 ) -> bool {
-    map.get(&(repo_name.to_string(), pkg_name.to_string()))
-        .is_some_and(|rows| {
-            rows.iter()
-                .any(|(family, installed)| *installed && family.as_deref() == pkg_family)
-        })
+    let key = (repo_name.to_string(), pkg_name.to_string());
+    let Some(rows) = map.get(&key) else {
+        return false;
+    };
+
+    if rows
+        .iter()
+        .any(|(family, installed)| *installed && family.as_deref() == pkg_family)
+    {
+        return true;
+    }
+
+    // Metadata can drop or rename the family a package was installed under,
+    // leaving nothing to match on. Where the repository offers the name once
+    // and one package is held under it, there is nothing else either could
+    // mean. Anything less certain is left unmatched rather than guessed.
+    if offered.get(&key).copied().unwrap_or(0) != 1 {
+        return false;
+    }
+
+    let mut held = rows.iter().filter(|(_, installed)| *installed);
+    held.next().is_some() && held.next().is_none()
 }
 
 /// The installed packages a URL or local path refers to.
@@ -595,6 +616,7 @@ fn package_from_source(source: &str) -> Option<(String, Option<String>)> {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::HashMap,
         fs::{self, File},
         path::PathBuf,
     };
@@ -602,7 +624,132 @@ mod tests {
     use soar_db::models::types::PackageProvide;
     use tempfile::{tempdir, TempDir};
 
-    use super::create_provide_symlinks;
+    use super::{create_provide_symlinks, is_installed, InstalledIndex, NameCounts};
+
+    /// One installed package of `name`, recorded under `family`.
+    fn installed_as(name: &str, family: Option<&str>, installed: bool) -> InstalledIndex {
+        HashMap::from([(
+            ("soarpkgs".to_string(), name.to_string()),
+            vec![(family.map(str::to_string), installed)],
+        )])
+    }
+
+    /// A repository offering `name` that many times over.
+    fn offering(name: &str, times: usize) -> NameCounts {
+        HashMap::from([(("soarpkgs".to_string(), name.to_string()), times)])
+    }
+
+    #[test]
+    fn a_family_dropped_by_later_metadata_still_matches_what_was_installed() {
+        // Installed when the metadata named the family after the package
+        // itself. The repository has since stopped carrying one.
+        let index = installed_as("widget", Some("widget"), true);
+
+        assert!(is_installed(
+            &index,
+            &offering("widget", 1),
+            "soarpkgs",
+            "widget",
+            None
+        ));
+        assert!(is_installed(
+            &index,
+            &offering("widget", 1),
+            "soarpkgs",
+            "widget",
+            Some("widget")
+        ));
+    }
+
+    #[test]
+    fn a_family_that_tells_two_packages_apart_still_has_to_match() {
+        // busybox is not the package's own name, so it goes on counting.
+        let index = installed_as("cat", Some("busybox"), true);
+
+        assert!(is_installed(
+            &index,
+            &offering("cat", 2),
+            "soarpkgs",
+            "cat",
+            Some("busybox")
+        ));
+        assert!(!is_installed(
+            &index,
+            &offering("cat", 2),
+            "soarpkgs",
+            "cat",
+            Some("toybox")
+        ));
+        assert!(!is_installed(
+            &index,
+            &offering("cat", 2),
+            "soarpkgs",
+            "cat",
+            None
+        ));
+    }
+
+    #[test]
+    fn a_family_renamed_outright_matches_where_the_name_stands_for_one_package() {
+        // Installed under a family the metadata no longer carries at all, so
+        // there is nothing left to match on but the name.
+        let index = installed_as("newpipe", Some("some.long.upstream-appimage"), true);
+
+        assert!(is_installed(
+            &index,
+            &offering("newpipe", 1),
+            "soarpkgs",
+            "newpipe",
+            None
+        ));
+    }
+
+    #[test]
+    fn a_name_the_repository_offers_twice_is_never_matched_on_the_name_alone() {
+        let index = installed_as("cat", Some("busybox"), true);
+
+        assert!(!is_installed(
+            &index,
+            &offering("cat", 2),
+            "soarpkgs",
+            "cat",
+            None
+        ));
+    }
+
+    #[test]
+    fn a_name_held_twice_over_is_not_matched_on_the_name_alone() {
+        // Two builds of the name held at once, so which was meant is unclear
+        // however few the repository offers.
+        let index: InstalledIndex = HashMap::from([(
+            ("soarpkgs".to_string(), "cat".to_string()),
+            vec![
+                (Some("busybox".to_string()), true),
+                (Some("toybox".to_string()), true),
+            ],
+        )]);
+
+        assert!(!is_installed(
+            &index,
+            &offering("cat", 1),
+            "soarpkgs",
+            "cat",
+            None
+        ));
+    }
+
+    #[test]
+    fn a_package_only_ever_uninstalled_is_not_installed() {
+        let index = installed_as("widget", Some("widget"), false);
+
+        assert!(!is_installed(
+            &index,
+            &offering("widget", 1),
+            "soarpkgs",
+            "widget",
+            None
+        ));
+    }
 
     fn setup() -> (TempDir, PathBuf, PathBuf) {
         let root = tempdir().unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installed-status detection in package lists and search results.
  - Packages are now matched to the correct family when multiple variants share the same name.
  - Family-independent matching is applied only when the package name is uniquely offered, reducing incorrect installation indicators.
  - Corrected handling for missing, renamed, duplicate, ambiguous, and unavailable package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->