### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 
+## [0.13.4](https://github.com/pkgforge/soar/compare/v0.13.3...v0.13.4) - 2026-09-05
+
+### ⛰️  Features
+
+- *(apply)* Add system = true for system-wide packages - ([57a6f9e](https://github.com/pkgforge/soar/commit/57a6f9e062140c60312e7b2e577a9dbe8ef21485))
+
+### 🐛 Bug Fixes
+
+- *(apply)* Write version updates to the file being applied - ([7ac7cf0](https://github.com/pkgforge/soar/commit/7ac7cf02871163a38ddc315019206834e77b9601))
+- *(apply)* Make "*" install the newest and stay unpinned - ([8ddda1c](https://github.com/pkgforge/soar/commit/8ddda1c3a3de3852284986aa3d2138645d638df9))
+- *(install)* Show only the newest of each package in the picker - ([7aab102](https://github.com/pkgforge/soar/commit/7aab102c4a3d1eedb92d57d621ff3ef982bf0521))
+- *(integrate)* Derive icon name from the desktop entry name - ([1a01304](https://github.com/pkgforge/soar/commit/1a0130415a03692d532aec9f202effcca54c8e55))
+- *(system)* Read packages.toml from /etc in system mode - ([4a35364](https://github.com/pkgforge/soar/commit/4a353647863c5821f1d36de596544016cacffd5a))
+
 ## [0.13.3](https://github.com/pkgforge/soar/compare/v0.13.2...v0.13.3) - 2026-08-31
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,7 +2219,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "soar-cli"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "soar-config"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "documented",
  "miette",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "soar-core"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "chrono",
  "compak",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "soar-db"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "soar-operations"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "fast-glob",
  "minisign-verify",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "soar-package"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "image",
  "miette",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "soar-registry"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "miette",
  "minisign-verify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,14 +60,14 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = { version = "1.0.151", features = ["indexmap"] }
 serial_test = "3.5.0"
 sha2 = "0.11.0"
-soar-config = { version = "0.12.2", path = "crates/soar-config" }
-soar-core = { version = "0.17.3", path = "crates/soar-core" }
-soar-db = { version = "0.7.1", path = "crates/soar-db" }
+soar-config = { version = "0.13.0", path = "crates/soar-config" }
+soar-core = { version = "0.17.4", path = "crates/soar-core" }
+soar-db = { version = "0.7.2", path = "crates/soar-db" }
 soar-dl = { version = "0.12.2", path = "crates/soar-dl" }
 soar-events = { version = "0.3.1", path = "crates/soar-events" }
-soar-operations = { version = "0.5.1", path = "crates/soar-operations" }
-soar-package = { version = "0.5.2", path = "crates/soar-package" }
-soar-registry = { version = "0.6.3", path = "crates/soar-registry" }
+soar-operations = { version = "0.6.0", path = "crates/soar-operations" }
+soar-package = { version = "0.6.0", path = "crates/soar-package" }
+soar-registry = { version = "0.6.4", path = "crates/soar-registry" }
 soar-utils = { version = "0.5.2", path = "crates/soar-utils" }
 squishy = { version = "0.5.1", features = ["appimage", "dwarfs"] }
 tabled = { version = "0.21", default-features = false, features = ["ansi"] }

--- a/crates/soar-cli/Cargo.toml
+++ b/crates/soar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-cli"
-version = "0.13.3"
+version = "0.13.4"
 description = "A modern package manager for Linux"
 default-run = "soar"
 license.workspace = true

--- a/crates/soar-config/CHANGELOG.md
+++ b/crates/soar-config/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.13.0](https://github.com/pkgforge/soar/compare/soar-config-v0.12.2...soar-config-v0.13.0) - 2026-09-05
+
+### ⛰️  Features
+
+- *(apply)* Add system = true for system-wide packages - ([57a6f9e](https://github.com/pkgforge/soar/commit/57a6f9e062140c60312e7b2e577a9dbe8ef21485))
+
+### 🐛 Bug Fixes
+
+- *(system)* Read packages.toml from /etc in system mode - ([4a35364](https://github.com/pkgforge/soar/commit/4a353647863c5821f1d36de596544016cacffd5a))
+
 ## [0.12.2](https://github.com/pkgforge/soar/compare/soar-config-v0.12.1...soar-config-v0.12.2) - 2026-08-31
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-config/Cargo.toml
+++ b/crates/soar-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-config"
-version = "0.12.2"
+version = "0.13.0"
 description = "Configuration management for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-core/CHANGELOG.md
+++ b/crates/soar-core/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.17.4](https://github.com/pkgforge/soar/compare/soar-core-v0.17.3...soar-core-v0.17.4) - 2026-09-05
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: soar-config, soar-package, soar-db - ([0000000](https://github.com/pkgforge/soar/commit/0000000))
+
 ## [0.17.3](https://github.com/pkgforge/soar/compare/soar-core-v0.17.2...soar-core-v0.17.3) - 2026-08-31
 
 ### 🐛 Bug Fixes

--- a/crates/soar-core/Cargo.toml
+++ b/crates/soar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-core"
-version = "0.17.3"
+version = "0.17.4"
 description = "Core library for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-db/CHANGELOG.md
+++ b/crates/soar-db/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.7.2](https://github.com/pkgforge/soar/compare/soar-db-v0.7.1...soar-db-v0.7.2) - 2026-09-05
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: soar-registry - ([0000000](https://github.com/pkgforge/soar/commit/0000000))
+
 ## [0.7.1](https://github.com/pkgforge/soar/compare/soar-db-v0.7.0...soar-db-v0.7.1) - 2026-08-31
 
 ### 🐛 Bug Fixes

--- a/crates/soar-db/Cargo.toml
+++ b/crates/soar-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-db"
-version = "0.7.1"
+version = "0.7.2"
 description = "Database operations for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-operations/CHANGELOG.md
+++ b/crates/soar-operations/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+## [0.6.0](https://github.com/pkgforge/soar/compare/soar-operations-v0.5.1...soar-operations-v0.6.0) - 2026-09-05
+
+### 🐛 Bug Fixes
+
+- *(apply)* Make "*" install the newest and stay unpinned - ([8ddda1c](https://github.com/pkgforge/soar/commit/8ddda1c3a3de3852284986aa3d2138645d638df9))
+- *(apply)* Write version updates to the file being applied - ([7ac7cf0](https://github.com/pkgforge/soar/commit/7ac7cf02871163a38ddc315019206834e77b9601))
+- *(install)* Show only the newest of each package in the picker - ([7aab102](https://github.com/pkgforge/soar/commit/7aab102c4a3d1eedb92d57d621ff3ef982bf0521))
+
 ## [0.5.1](https://github.com/pkgforge/soar/compare/soar-operations-v0.5.0...soar-operations-v0.5.1) - 2026-08-31
 
 ### ⛰️  Features

--- a/crates/soar-operations/Cargo.toml
+++ b/crates/soar-operations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-operations"
-version = "0.5.1"
+version = "0.6.0"
 description = "Business logic for soar package manager"
 license.workspace = true
 edition.workspace = true

--- a/crates/soar-package/CHANGELOG.md
+++ b/crates/soar-package/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.6.0](https://github.com/pkgforge/soar/compare/soar-package-v0.5.2...soar-package-v0.6.0) - 2026-09-05
+
+### 🐛 Bug Fixes
+
+- *(integrate)* Derive icon name from the desktop entry name - ([1a01304](https://github.com/pkgforge/soar/commit/1a0130415a03692d532aec9f202effcca54c8e55))
+
 ## [0.5.2](https://github.com/pkgforge/soar/compare/soar-package-v0.5.1...soar-package-v0.5.2) - 2026-08-31
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/soar-package/Cargo.toml
+++ b/crates/soar-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-package"
-version = "0.5.2"
+version = "0.6.0"
 description = "Package format handling for soar package manager"
 edition.workspace = true
 readme.workspace = true

--- a/crates/soar-registry/CHANGELOG.md
+++ b/crates/soar-registry/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.6.4](https://github.com/pkgforge/soar/compare/soar-registry-v0.6.3...soar-registry-v0.6.4) - 2026-09-05
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: soar-config - ([0000000](https://github.com/pkgforge/soar/commit/0000000))
+
 ## [0.6.3](https://github.com/pkgforge/soar/compare/soar-registry-v0.6.2...soar-registry-v0.6.3) - 2026-08-31
 
 ### 🐛 Bug Fixes

--- a/crates/soar-registry/Cargo.toml
+++ b/crates/soar-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar-registry"
-version = "0.6.3"
+version = "0.6.4"
 description = "Registry management for soar package manager"
 edition.workspace = true
 readme.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `soar-config`: 0.12.2 -> 0.13.0 (⚠ API breaking changes)
* `soar-package`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)
* `soar-operations`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `soar-cli`: 0.13.3 -> 0.13.4
* `soar-registry`: 0.6.3 -> 0.6.4
* `soar-db`: 0.7.1 -> 0.7.2
* `soar-core`: 0.17.3 -> 0.17.4

### ⚠ `soar-config` breaking changes

```text
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Description:
A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PackageDefaults.system in /tmp/.tmpGmS7lu/soar/crates/soar-config/src/packages.rs:51
  field ResolvedPackage.system in /tmp/.tmpGmS7lu/soar/crates/soar-config/src/packages.rs:368
  field PackageOptions.system in /tmp/.tmpGmS7lu/soar/crates/soar-config/src/packages.rs:259
```

### ⚠ `soar-package` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_parameter_count_changed.ron

Failed in:
  soar_package::formats::appimage::integrate_appimage now takes 7 parameters instead of 6, in /tmp/.tmpGmS7lu/soar/crates/soar-package/src/formats/appimage.rs:37
  soar_package::formats::common::symlink_icon_with_mode now takes 3 parameters instead of 2, in /tmp/.tmpGmS7lu/soar/crates/soar-package/src/formats/common.rs:98
  soar_package::formats::onelf::integrate_onelf now takes 7 parameters instead of 6, in /tmp/.tmpGmS7lu/soar/crates/soar-package/src/formats/onelf.rs:185
```

### ⚠ `soar-operations` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_parameter_count_changed.ron

Failed in:
  soar_operations::apply::execute_apply now takes 4 parameters instead of 3, in /tmp/.tmpGmS7lu/soar/crates/soar-operations/src/apply.rs:230
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `soar-config`

<blockquote>

## [0.13.0](https://github.com/pkgforge/soar/compare/soar-config-v0.12.2...soar-config-v0.13.0) - 2026-09-05

### ⛰️  Features

- *(apply)* Add system = true for system-wide packages - ([57a6f9e](https://github.com/pkgforge/soar/commit/57a6f9e062140c60312e7b2e577a9dbe8ef21485))

### 🐛 Bug Fixes

- *(system)* Read packages.toml from /etc in system mode - ([4a35364](https://github.com/pkgforge/soar/commit/4a353647863c5821f1d36de596544016cacffd5a))
</blockquote>

## `soar-package`

<blockquote>

## [0.6.0](https://github.com/pkgforge/soar/compare/soar-package-v0.5.2...soar-package-v0.6.0) - 2026-09-05

### 🐛 Bug Fixes

- *(integrate)* Derive icon name from the desktop entry name - ([1a01304](https://github.com/pkgforge/soar/commit/1a0130415a03692d532aec9f202effcca54c8e55))
</blockquote>

## `soar-operations`

<blockquote>

## [0.6.0](https://github.com/pkgforge/soar/compare/soar-operations-v0.5.1...soar-operations-v0.6.0) - 2026-09-05

### 🐛 Bug Fixes

- *(apply)* Make "*" install the newest and stay unpinned - ([8ddda1c](https://github.com/pkgforge/soar/commit/8ddda1c3a3de3852284986aa3d2138645d638df9))
- *(apply)* Write version updates to the file being applied - ([7ac7cf0](https://github.com/pkgforge/soar/commit/7ac7cf02871163a38ddc315019206834e77b9601))
- *(install)* Show only the newest of each package in the picker - ([7aab102](https://github.com/pkgforge/soar/commit/7aab102c4a3d1eedb92d57d621ff3ef982bf0521))
</blockquote>

## `soar-cli`

<blockquote>

## [0.13.4](https://github.com/pkgforge/soar/compare/v0.13.3...v0.13.4) - 2026-09-05

### ⛰️  Features

- *(apply)* Add system = true for system-wide packages - ([57a6f9e](https://github.com/pkgforge/soar/commit/57a6f9e062140c60312e7b2e577a9dbe8ef21485))

### 🐛 Bug Fixes

- *(apply)* Write version updates to the file being applied - ([7ac7cf0](https://github.com/pkgforge/soar/commit/7ac7cf02871163a38ddc315019206834e77b9601))
- *(apply)* Make "*" install the newest and stay unpinned - ([8ddda1c](https://github.com/pkgforge/soar/commit/8ddda1c3a3de3852284986aa3d2138645d638df9))
- *(install)* Show only the newest of each package in the picker - ([7aab102](https://github.com/pkgforge/soar/commit/7aab102c4a3d1eedb92d57d621ff3ef982bf0521))
- *(integrate)* Derive icon name from the desktop entry name - ([1a01304](https://github.com/pkgforge/soar/commit/1a0130415a03692d532aec9f202effcca54c8e55))
- *(system)* Read packages.toml from /etc in system mode - ([4a35364](https://github.com/pkgforge/soar/commit/4a353647863c5821f1d36de596544016cacffd5a))
</blockquote>

## `soar-registry`

<blockquote>

## [0.6.4](https://github.com/pkgforge/soar/compare/soar-registry-v0.6.3...soar-registry-v0.6.4) - 2026-09-05

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: soar-config - ([0000000](https://github.com/pkgforge/soar/commit/0000000))
</blockquote>

## `soar-db`

<blockquote>

## [0.7.2](https://github.com/pkgforge/soar/compare/soar-db-v0.7.1...soar-db-v0.7.2) - 2026-09-05

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: soar-registry - ([0000000](https://github.com/pkgforge/soar/commit/0000000))
</blockquote>

## `soar-core`

<blockquote>

## [0.17.4](https://github.com/pkgforge/soar/compare/soar-core-v0.17.3...soar-core-v0.17.4) - 2026-09-05

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: soar-config, soar-package, soar-db - ([0000000](https://github.com/pkgforge/soar/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying system-wide packages with `system = true`.
* **Bug Fixes**
  * System mode now reads package definitions from `/etc`.
  * Applying updates the file being applied with the correct version.
  * Using `*` installs the newest package without pinning it.
  * Package pickers show only the newest version of each package.
  * Application icons now use the desktop entry name correctly.
* **Documentation**
  * Added release notes for the latest changes across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->